### PR TITLE
fix:文档、示例代码、链接错误

### DIFF
--- a/docs/rules/no-multiple-template-root.md
+++ b/docs/rules/no-multiple-template-root.md
@@ -11,7 +11,7 @@ description: disallow adding multiple root nodes to the template
 
 ## :book: Rule Details
 
-This rule checks whether template contains single root element valid for Vue 2.
+This rule checks whether template contains single root element valid for San.
 
 <eslint-code-block :rules="{'san/no-multiple-template-root': ['error']}">
 
@@ -62,5 +62,5 @@ Nothing.
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-multiple-template-root.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-multiple-template-root.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-multiple-template-root.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-multiple-template-root.js)

--- a/docs/rules/no-parsing-error.md
+++ b/docs/rules/no-parsing-error.md
@@ -31,7 +31,7 @@ Then reports syntax errors if exist.
   <!-- ✗ BAD -->
   {{ . }}
   {{ foo bar }}
-  <div :class="*abc*" / @click="def(">
+  <div class={{*abc*}} / on-click="def(">
     </span>
   </div id="ghi">
 </template>
@@ -102,5 +102,5 @@ The error codes which have `x-` prefix are original of this rule because errors 
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-parsing-error.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-parsing-error.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-parsing-error.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-parsing-error.js)

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -11,7 +11,7 @@ description: disallow overwriting reserved keys
 
 ## :book: Rule Details
 
-This rule prevents to use [reserved names](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/utils/vue-reserved.json) to avoid conflicts and unexpected behavior.
+This rule prevents to use [reserved names](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/utils/san-reserved.json) to avoid conflicts and unexpected behavior.
 
 <eslint-code-block :rules="{'san/no-reserved-keys': ['error']}">
 
@@ -20,18 +20,15 @@ This rule prevents to use [reserved names](https://github.com/vuejs/eslint-plugi
 /* ✗ BAD */
 export default {
   props: {
-    $el: String
+    el: String
   },
   computed: {
-    $on: {
-      get () {}
+    fire() {
+      return 3;
     }
   },
-  data: {
-    _foo: null
-  },
   methods: {
-    $nextTick () {}
+    nextTick () {}
   }
 }
 </script>
@@ -41,43 +38,13 @@ export default {
 
 ## :wrench: Options
 
-```json
-{
-  "san/no-reserved-keys": ["error", {
-    "reserved": [],
-    "groups": []
-  }]
-}
-```
-
-- `reserved` (`string[]`) ... Array of additional restricted attributes inside `groups`. Default is empty.
-- `groups` (`string[]`) ... Array of additional group names to search for duplicates in. Default is empty.
-
-### `"reserved": ["foo", "foo2"], "groups": ["firebase"]`
-
-<eslint-code-block :rules="{'san/no-reserved-keys': ['error', {reserved: ['foo', 'foo2'], groups: ['firebase']}]}">
-
-```vue
-<script>
-/* ✗ BAD */
-export default {
-  computed: {
-    foo () {}
-  },
-  firebase: {
-    foo2 () {}
-  }
-}
-</script>
-```
-
-</eslint-code-block>
+Nothing.
 
 ## :books: Further Reading
 
-- [List of reserved keys](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/utils/vue-reserved.json)
+- [List of reserved keys](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/utils/san-reserved.json)
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-reserved-keys.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-reserved-keys.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-reserved-keys.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-reserved-keys.js)

--- a/docs/rules/no-shared-component-data.md
+++ b/docs/rules/no-shared-component-data.md
@@ -10,7 +10,7 @@ description: enforce component's data property to be a function
 - :gear: This rule is included in all of `"plugin:san/essential"`, `"plugin:san/strongly-recommended"` and `"plugin:san/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-When using the data property on a component (i.e. anywhere except on `new Vue`), the value must be a function that returns an object.
+When using the data property on a component , the value must be a function that returns an object.
 
 ## :book: Rule Details
 
@@ -21,13 +21,13 @@ When the value of `data` is an object, it’s shared across all instances of a c
 ```vue
 <script>
 /* ✓ GOOD */
-Vue.component('some-comp', {
-  data: function () {
+export default class SomeComp extends san.Component {
+  initData () {
     return {
       foo: 'bar'
     }
   }
-})
+}
 
 export default {
   data () {
@@ -46,8 +46,8 @@ export default {
 ```vue
 <script>
 /* ✗ BAD */
-Vue.component('some-comp', {
-  data: {
+export default class SomeComp extends san.Component {
+  static data = {
     foo: 'bar'
   }
 })
@@ -68,11 +68,9 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide (for v2) - Component data](https://vuejs.org/v2/style-guide/#Component-data-essential)
-- [API - data](https://v3.vuejs.org/api/options-data.html#data-2)
-- [API (for v2) - data](https://v3.vuejs.org/api/options-data.html#data-2)
+- [API - data](https://baidu.github.io/san/tutorial/data-method/)
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-shared-component-data.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-shared-component-data.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-shared-component-data.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-shared-component-data.js)

--- a/docs/rules/no-side-effects-in-computed-properties.md
+++ b/docs/rules/no-side-effects-in-computed-properties.md
@@ -23,10 +23,13 @@ It is considered a very bad practice to introduce side effects inside computed p
 export default {
   computed: {
     fullName () {
+      const firstName = this.data.get('firstName')
+      const lastName = this.data.get('lastName')
+
       return `${this.firstName} ${this.lastName}`
     },
     reversedArray () {
-      return this.array.slice(0).reverse() // .slice makes a copy of the array, instead of mutating the orginal
+      return this.data.get('array').slice(0).reverse() // .slice makes a copy of the array, instead of mutating the orginal
     }
   }
 }
@@ -43,11 +46,11 @@ export default {
 export default {
   computed: {
     fullName () {
-      this.firstName = 'lorem' // <- side effect
-      return `${this.firstName} ${this.lastName}`
+      this.data.set('firstName') = 'lorem' // <- side effect
+      return `${this.data.set('firstName')} ${this.data.set('lastName')}`
     },
     reversedArray () {
-      return this.array.reverse() // <- side effect - orginal array is being mutated
+      return this.data.get('array').reverse() // <- side effect - orginal array is being mutated
     }
   }
 }
@@ -62,9 +65,9 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Guide - Computed Caching vs Methods](https://v3.vuejs.org/guide/computed.html#computed-caching-vs-methods)
+- [Guide - Computed](https://baidu.github.io/san/tutorial/component/#计算数据)
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-side-effects-in-computed-properties.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-side-effects-in-computed-properties.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-side-effects-in-computed-properties.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-side-effects-in-computed-properties.js)

--- a/docs/rules/no-template-shadow.md
+++ b/docs/rules/no-template-shadow.md
@@ -27,7 +27,6 @@ This rule aims to eliminate shadowed variable declarations of s-for directives o
   <div>
     <div s-for="k in 5">
       <div s-for="k in 10"></div>
-      <div slot-scope="{ k }"></div>
     </div>
   </div>
   <div s-for="l in 5"></div>
@@ -52,5 +51,5 @@ Nothing.
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-template-shadow.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-template-shadow.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-template-shadow.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-template-shadow.js)

--- a/docs/rules/no-textarea-mustache.md
+++ b/docs/rules/no-textarea-mustache.md
@@ -18,7 +18,7 @@ This rule reports mustaches in `<textarea>`.
 ```vue
 <template>
   <!-- ✓ GOOD -->
-  <textarea s-model="message" />
+  <textarea value="{=message=}" />
 
   <!-- ✗ BAD -->
   <textarea>{{ message }}</textarea>
@@ -27,20 +27,15 @@ This rule reports mustaches in `<textarea>`.
 
 </eslint-code-block>
 
-::: warning Note
-Interpolation on textareas (`<textarea>{{text}}</textarea>`) won't work. Use `s-model` instead.
-[https://v3.vuejs.org/guide/forms.html#multiline-text](https://v3.vuejs.org/guide/forms.html#multiline-text)
-:::
-
 ## :wrench: Options
 
 Nothing.
 
 ## :books: Further Reading
 
-- [Guide - Form Input Bindings / Multiline text](https://v3.vuejs.org/guide/forms.html#multiline-text)
+- [Guide - Form Input Bindings / Multiline text](https://baidu.github.io/san/tutorial/form/#输入框)
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-textarea-mustache.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-textarea-mustache.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-textarea-mustache.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-textarea-mustache.js)

--- a/docs/rules/no-unused-components.md
+++ b/docs/rules/no-unused-components.md
@@ -21,25 +21,19 @@ This rule reports components that haven't been used in the template.
   <div>
     <h2>Lorem ipsum</h2>
     <the-modal>
-      <component is="TheInput" />
-      <component :is="'TheDropdown'" />
-      <TheButton>CTA</TheButton>
+      <the-button>CTA</the-button>
     </the-modal>
   </div>
 </template>
 
 <script>
-  import TheButton from 'components/TheButton.vue'
-  import TheModal from 'components/TheModal.vue'
-  import TheInput from 'components/TheInput.vue'
-  import TheDropdown from 'components/TheDropdown.vue'
+  import TheButton from 'components/TheButton.san'
+  import TheModal from 'components/TheModal.san'
 
   export default {
     components: {
       TheButton,
-      TheModal,
-      TheInput,
-      TheDropdown,
+      TheModal
     }
   }
 </script>
@@ -54,18 +48,18 @@ This rule reports components that haven't been used in the template.
 <template>
   <div>
     <h2>Lorem ipsum</h2>
-    <TheModal />
+    <the-modal />
   </div>
 </template>
 
 <script>
-  import TheButton from 'components/TheButton.vue'
-  import TheModal from 'components/TheModal.vue'
+  import TheButton from 'components/TheButton.san'
+  import TheModal from 'components/TheModal.san'
 
   export default {
     components: {
-      TheButton, // Unused component
-      'the-modal': TheModal // Unused component
+      'the-button': TheButton, // Unused component
+      'the-modal': TheModal // Used component
     }
   }
 </script>
@@ -73,9 +67,6 @@ This rule reports components that haven't been used in the template.
 
 </eslint-code-block>
 
-::: warning Note
-Components registered under `PascalCase` or `camelCase` names have may be called however you like, except using `snake_case`. Otherwise, they will need to be called directly under the specified name.
-:::
 
 ## :wrench: Options
 
@@ -99,22 +90,22 @@ Components registered under `PascalCase` or `camelCase` names have may be called
 <template>
   <div>
     <h2>Lorem ipsum</h2>
-    <TheButton s-if="" />
-    <TheSelect s-else-if="" />
-    <TheInput s-else="" />
+    <the-button s-if="" />
+    <the-select s-else-if="" />
+    <the-input s-else="" />
   </div>
 </template>
 
 <script>
-  import TheButton from 'components/TheButton.vue'
-  import TheSelect from 'components/TheSelect.vue'
-  import TheInput from 'components/TheInput.vue'
+  import TheButton from 'components/TheButton.san'
+  import TheSelect from 'components/TheSelect.san'
+  import TheInput from 'components/TheInput.san'
 
   export default {
     components: {
-      TheButton,
-      TheSelect,
-      TheInput,
+      'the-button': TheButton,
+      'the-select': TheSelect,
+      'the-input': TheInput,
     },
   }
 </script>
@@ -129,20 +120,20 @@ Components registered under `PascalCase` or `camelCase` names have may be called
 <template>
   <div>
     <h2>Lorem ipsum</h2>
-    <component :is="computedComponent" />
+    <computedComponent />
   </div>
 </template>
 
 <script>
-  import TheButton from 'components/TheButton.vue'
-  import TheSelect from 'components/TheSelect.vue'
-  import TheInput from 'components/TheInput.vue'
+  import TheButton from 'components/TheButton.san'
+  import TheSelect from 'components/TheSelect.san'
+  import TheInput from 'components/TheInput.san'
 
   export default {
     components: {
-      TheButton, // <- not used
-      TheSelect, // <- not used
-      TheInput, // <- not used
+      'the-button': TheButton, // <- not used
+      'the-select': TheSelect, // <- not used
+      'the-input': TheInput, // <- not used
     },
     computed: {
       computedComponent() {
@@ -156,5 +147,5 @@ Components registered under `PascalCase` or `camelCase` names have may be called
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-unused-components.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-unused-components.js)
+- [Rule source](https://github.com/ecom/eslint-plugin-san/blob/master/lib/rules/no-unused-components.js)
+- [Test source](https://github.com/ecom/eslint-plugin-san/blob/master/tests/lib/rules/no-unused-components.js)

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -49,5 +49,5 @@ This rule report variable definitions of s-for directives or scope attributes if
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-unused-vars.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-unused-vars.js)
+- [Rule source](https://github.com/ecom/eslint-plugin-san/blob/master/lib/rules/no-unused-vars.js)
+- [Test source](https://github.com/ecom/eslint-plugin-san/blob/master/tests/lib/rules/no-unused-vars.js)

--- a/docs/rules/no-use-s-if-with-s-for.md
+++ b/docs/rules/no-use-s-if-with-s-for.md
@@ -23,26 +23,26 @@ There are two common cases where this can be tempting:
 <template>
   <!-- ✓ GOOD -->
   <ul s-if="complete">
-    <TodoItem
+    <todo-item
       s-for="todo in todos"
-      :todo="todo"
+      todo="{{todo}}"
     />
   </ul>
-  <TodoItem
+  <todo-item
     s-for="todo in shownTodos"
-    :todo="todo"
+    todo="{{todo}}"
   />
 
   <!-- ✗ BAD -->
-  <TodoItem
+  <todo-item
     s-if="complete"
     s-for="todo in todos"
-    :todo="todo"
+    todo="{{todo}}"
   /><!-- ↑ In this case, the `s-if` should be written on the wrapper element. -->
-  <TodoItem
+  <todo-item
     s-for="todo in todos"
     s-if="todo.shown"
-    :todo="todo"
+    todo="{{todo}}"
   /><!-- ↑ In this case, the `s-for` list variable should be replace with a computed property that returns your filtered list. -->
 </template>
 ```
@@ -68,30 +68,25 @@ There are two common cases where this can be tempting:
 ```vue
 <template>
   <!-- ✓ GOOD -->
-  <TodoItem
+  <todo-item
     s-for="todo in todos"
     s-if="todo.shown"
-    :todo="todo"
+    todo="{{todo}}"
   />
 
   <!-- ✗ BAD -->
-  <TodoItem
+  <todo-item
     s-for="todo in todos"
     s-if="shown"
-    :todo="todo"
+    todo="{{todo}}"
   />
 </template>
 ```
 
 </eslint-code-block>
 
-## :books: Further Reading
-
-- [Style guide - Avoid s-if with s-for](https://v3.vuejs.org/style-guide/#avoid-s-if-with-s-for-essential)
-- [Guide - Conditional Rendering / s-if with s-for](https://v3.vuejs.org/guide/conditional.html#s-if-with-s-for)
-- [Guide - List Rendering / s-for with s-if](https://v3.vuejs.org/guide/list.html#s-for-with-s-if)
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/vuejs/eslint-plugin-san/blob/master/lib/rules/no-use-s-if-with-s-for.js)
-- [Test source](https://github.com/vuejs/eslint-plugin-san/blob/master/tests/lib/rules/no-use-s-if-with-s-for.js)
+- [Rule source](https://github.com/ecom/eslint-plugin-san/blob/master/lib/rules/no-use-s-if-with-s-for.js)
+- [Test source](https://github.com/ecom/eslint-plugin-san/blob/master/tests/lib/rules/no-use-s-if-with-s-for.js)


### PR DESCRIPTION
fix如下rule的文档

no-multiple-template-root
no-parsing-error
no-reserved-keys
no-shared-component-data
no-side-effects-in-computed-properties
no-template-shadow
no-textarea-mustache
no-unused-components
no-unused-vars
no-use-s-if-with-s-for