### PR TITLE
fix: 修复无法识别类组件以及相关的8条规则

### DIFF
--- a/__tests__/lib/rules/attributes-order.test.js
+++ b/__tests__/lib/rules/attributes-order.test.js
@@ -646,6 +646,7 @@ tester.run('attributes-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `<template>
             <div
               class="content"
@@ -687,6 +688,7 @@ tester.run('attributes-order', rule, {
             ]
         },
         {
+          filename: 'test.san',
             code: `<template>
             <my-component
               s-if="!visible"

--- a/__tests__/lib/rules/component-tags-order.test.js
+++ b/__tests__/lib/rules/component-tags-order.test.js
@@ -53,37 +53,44 @@ tester.run('component-tags-order', rule, {
 
         // order
         {
+            filename: 'test.san',
             code: '<script></script><template></template><style></style>',
             output: null,
             options: [{order: ['script', 'template', 'style']}]
         },
         {
+            filename: 'test.san',
             code: '<template></template><script></script><style></style>',
             output: null,
             options: [{order: ['template', 'script', 'style']}]
         },
         {
+            filename: 'test.san',
             code: '<style></style><template></template><script></script>',
             output: null,
             options: [{order: ['style', 'template', 'script']}]
         },
         {
+            filename: 'test.san',
             code: '<template></template><script></script><style></style>',
             output: null,
             options: [{order: ['template', 'docs', 'script', 'style']}]
         },
         {
+            filename: 'test.san',
             code: '<template></template><docs></docs><script></script><style></style>',
             output: null,
             options: [{order: ['template', 'script', 'style']}]
         },
         {
+            filename: 'test.san',
             code:
                 '<docs><div id="id">text <!--comment--> </div><br></docs><script></script><template></template><style></style>',
             output: null,
             options: [{order: ['docs', 'script', 'template', 'style']}]
         },
         {
+            filename: 'test.san',
             code: '<template></template><docs></docs><script></script><style></style>',
             output: null,
             options: [{order: [['docs', 'script', 'template'], 'style']}]
@@ -97,6 +104,7 @@ tester.run('component-tags-order', rule, {
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: '<style></style><template></template><script></script>',
             errors: [
                 {
@@ -112,6 +120,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template></template><script></script><style></style>',
             options: [{order: ['script', 'template', 'style']}],
             errors: [
@@ -123,6 +132,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
             <template></template>
 
@@ -137,6 +147,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template></template>
                 <script></script>
@@ -151,6 +162,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <script></script>
                 <template></template>
@@ -165,6 +177,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template></template>
                 <docs></docs>
@@ -180,6 +193,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template></template>
                 <docs></docs>
@@ -195,6 +209,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template></template>
                 <docs>
@@ -211,6 +226,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <script></script>
                 <template></template>
@@ -224,6 +240,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <style></style>
                 <template></template>
@@ -241,6 +258,7 @@ tester.run('component-tags-order', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <style></style>
                 <docs></docs>
@@ -260,6 +278,7 @@ tester.run('component-tags-order', rule, {
         },
         // no <template>
         {
+            filename: 'test.san',
             code: `
                 <style></style>
                 <script></script>

--- a/__tests__/lib/rules/html-closing-bracket-newline.test.js
+++ b/__tests__/lib/rules/html-closing-bracket-newline.test.js
@@ -37,6 +37,7 @@ tester.run('html-closing-bracket-newline', rule, {
         </template>
         `,
         {
+            filename: 'test.san',
             code: `<template><div></div></template>`,
             options: [
                 {
@@ -46,6 +47,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -61,6 +63,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -77,6 +80,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div id="">
@@ -91,6 +95,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template
                 >
@@ -109,6 +114,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template
                 >
@@ -137,6 +143,7 @@ tester.run('html-closing-bracket-newline', rule, {
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -156,6 +163,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -174,6 +182,7 @@ tester.run('html-closing-bracket-newline', rule, {
             errors: ['Expected 1 line break before closing bracket, but no line breaks found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -199,6 +208,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -223,6 +233,7 @@ tester.run('html-closing-bracket-newline', rule, {
             errors: ['Expected no line breaks before closing bracket, but 1 line break found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -247,6 +258,7 @@ tester.run('html-closing-bracket-newline', rule, {
             errors: ['Expected 1 line break before closing bracket, but no line breaks found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div id=""
@@ -273,6 +285,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template
                 >
@@ -305,6 +318,7 @@ tester.run('html-closing-bracket-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template
                 >

--- a/__tests__/lib/rules/html-closing-bracket-spacing.test.js
+++ b/__tests__/lib/rules/html-closing-bracket-spacing.test.js
@@ -32,30 +32,36 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
         '<template><div foo=a></div><div foo=a /></template>',
         '<template><div foo="a"></div><div foo="a" /></template>',
         {
+            filename: 'test.san',
             code: '<template ><div ></div><div /></template>',
             options: [{startTag: 'always'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div></div ><div /></template >',
             options: [{endTag: 'always'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div></div><div/></template>',
             options: [{selfClosingTag: 'never'}]
         },
         '<template><div',
         '<template><div></div',
         {
+            filename: 'test.san',
             code: '<template><div',
             options: [{startTag: 'never', endTag: 'never'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div></div',
             options: [{startTag: 'never', endTag: 'never'}]
         }
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: '<template>\n  <div >\n  </div >\n  <div/>\n</template>',
             output: '<template>\n  <div>\n  </div>\n  <div />\n</template>',
             errors: [
@@ -80,6 +86,7 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template>\n  <div foo ></div>\n  <div foo/>\n</template>',
             output: '<template>\n  <div foo></div>\n  <div foo />\n</template>',
             errors: [
@@ -98,6 +105,7 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template>\n  <div foo="1" ></div>\n  <div foo="1"/>\n</template>',
             output: '<template>\n  <div foo="1"></div>\n  <div foo="1" />\n</template>',
             errors: [
@@ -116,6 +124,7 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template >\n  <div>\n  </div>\n  <div />\n</template >',
             output: '<template >\n  <div >\n  </div >\n  <div/>\n</template >',
             options: [

--- a/__tests__/lib/rules/html-self-closing.test.js
+++ b/__tests__/lib/rules/html-self-closing.test.js
@@ -65,6 +65,7 @@ tester.run('html-self-closing', rule, {
 
         // Don't error if there are comments in their content.
         {
+            filename: 'test.san',
             code: '<template><div><!-- comment --></div></template>',
             output: null,
             options: [{html: {normal: 'always'}}]
@@ -79,26 +80,31 @@ tester.run('html-self-closing', rule, {
     invalid: [
         // default
         {
+            filename: 'test.san',
             code: '<template><div></div></template>',
             output: '<template><div/></template>',
             errors: ['Require self-closing on HTML elements (<div>).']
         },
         {
+            filename: 'test.san',
             code: '<template><img/></template>',
             output: '<template><img></template>',
             errors: ['Disallow self-closing on HTML void elements (<img/>).']
         },
         {
+            filename: 'test.san',
             code: '<template><x-test></x-test></template>',
             output: '<template><x-test/></template>',
             errors: ['Require self-closing on San.js custom components (<x-test>).']
         },
         {
+            filename: 'test.san',
             code: '<template><svg><path></path></svg></template>',
             output: '<template><svg><path/></svg></template>',
             errors: ['Require self-closing on SVG elements (<path>).']
         },
         {
+            filename: 'test.san',
             code: '<template><math><mspace></mspace></math></template>',
             output: '<template><math><mspace/></math></template>',
             errors: ['Require self-closing on MathML elements (<mspace>).']
@@ -106,6 +112,7 @@ tester.run('html-self-closing', rule, {
 
         // others
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div/>
@@ -123,6 +130,7 @@ tester.run('html-self-closing', rule, {
             errors: [{message: 'Require self-closing on HTML elements (<div>).', line: 2}]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -140,6 +148,7 @@ tester.run('html-self-closing', rule, {
             errors: [{message: 'Disallow self-closing on HTML elements (<div/>).', line: 3}]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -162,6 +171,7 @@ tester.run('html-self-closing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -184,6 +194,7 @@ tester.run('html-self-closing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -206,6 +217,7 @@ tester.run('html-self-closing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -228,6 +240,7 @@ tester.run('html-self-closing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -245,6 +258,7 @@ tester.run('html-self-closing', rule, {
             errors: [{message: 'Require self-closing on SVG elements (<path>).', line: 8}]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -262,6 +276,7 @@ tester.run('html-self-closing', rule, {
             errors: [{message: 'Disallow self-closing on SVG elements (<path/>).', line: 9}]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>
@@ -284,6 +299,7 @@ tester.run('html-self-closing', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: ALL_CODE,
             output: `<template>
     <div></div>

--- a/__tests__/lib/rules/max-attributes-per-line.test.js
+++ b/__tests__/lib/rules/max-attributes-per-line.test.js
@@ -25,9 +25,11 @@ const ruleTester = new RuleTester({
 ruleTester.run('max-attributes-per-line', rule, {
     valid: [
         {
+            filename: 'test.san',
             code: `<template><component></component></template>`
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe"
         age="30"
@@ -35,6 +37,7 @@ ruleTester.run('max-attributes-per-line', rule, {
       ></component></template>`
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe"
         age="30"
@@ -43,6 +46,7 @@ ruleTester.run('max-attributes-per-line', rule, {
             options: [{multiline: {allowFirstLine: true}}]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe"
         age="30"
@@ -50,6 +54,7 @@ ruleTester.run('max-attributes-per-line', rule, {
       </component></template>`
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe"
         age="30">
@@ -58,14 +63,17 @@ ruleTester.run('max-attributes-per-line', rule, {
             options: [{singleline: 1}]
         },
         {
+            filename: 'test.san',
             code: `<template><component></component></template>`,
             options: [{singleline: 1, multiline: {max: 1, allowFirstLine: false}}]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
             options: [{singleline: 3, multiline: {max: 1, allowFirstLine: false}}]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe"
         age="30">
         </component>
@@ -73,6 +81,7 @@ ruleTester.run('max-attributes-per-line', rule, {
             options: [{singleline: 3, multiline: {max: 1, allowFirstLine: true}}]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe"
         age="30">
@@ -81,6 +90,7 @@ ruleTester.run('max-attributes-per-line', rule, {
             options: [{singleline: 3, multiline: {max: 1, allowFirstLine: false}}]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe" age="30"
         job="Vet">
@@ -92,48 +102,56 @@ ruleTester.run('max-attributes-per-line', rule, {
 
     invalid: [
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe" age="30"></component></template>`,
             output: `<template><component name="John Doe"
 age="30"></component></template>`,
             errors: ["'age' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component :name="user.name" :age="user.age"></component></template>`,
             output: `<template><component :name="user.name"
 :age="user.age"></component></template>`,
             errors: ["':age' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component :is="test" s-bind="user"></component></template>`,
             output: `<template><component :is="test"
 s-bind="user"></component></template>`,
             errors: ["'s-bind' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component :name="user.name" @buy="buyProduct"></component></template>`,
             output: `<template><component :name="user.name"
 @buy="buyProduct"></component></template>`,
             errors: ["'@buy' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component :name="user.name" @click.stop></component></template>`,
             output: `<template><component :name="user.name"
 @click.stop></component></template>`,
             errors: ["'@click.stop' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component :name="user.name" s-if="something"></component></template>`,
             output: `<template><component :name="user.name"
 s-if="something"></component></template>`,
             errors: ["'s-if' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe"    s-bind:age="user.age"></component></template>`,
             output: `<template><component name="John Doe"
 s-bind:age="user.age"></component></template>`,
             errors: ["'s-bind:age' should be on a new line."]
         },
         {
+            filename: 'test.san',
             code: `<template><component job="Vet"
         name="John Doe"
         age="30">
@@ -154,6 +172,7 @@ job="Vet"
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
             options: [{singleline: {max: 2}}],
             output: `<template><component name="John Doe" age="30"
@@ -167,6 +186,7 @@ job="Vet"></component></template>`,
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
             options: [{singleline: 1, multiline: {max: 1, allowFirstLine: false}}],
             output: `<template><component name="John Doe"
@@ -185,6 +205,7 @@ age="30" job="Vet"></component></template>`,
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component name="John Doe"
         age="30">
         </component>
@@ -204,6 +225,7 @@ name="John Doe"
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe" age="30"
         job="Vet">
@@ -225,6 +247,7 @@ age="30"
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe" age="30"
         job="Vet">
@@ -246,6 +269,7 @@ age="30"
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe" age="30"
         job="Vet" pet="dog" petname="Snoopy">
@@ -267,6 +291,7 @@ petname="Snoopy">
             ]
         },
         {
+            filename: 'test.san',
             code: `<template><component
         name="John Doe" age="30"
         job="Vet" pet="dog" petname="Snoopy" extra="foo">

--- a/__tests__/lib/rules/multiline-html-element-content-newline.test.js
+++ b/__tests__/lib/rules/multiline-html-element-content-newline.test.js
@@ -147,6 +147,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
         // allowEmptyLines
         {
+            filename: 'test.san',
             code: `
             <template>
                 <div
@@ -157,6 +158,7 @@ tester.run('multiline-html-element-content-newline', rule, {
             options: [{allowEmptyLines: true, ignoreWhenEmpty: false}]
         },
         {
+            filename: 'test.san',
             code: `
             <template>
                 <div
@@ -169,6 +171,7 @@ tester.run('multiline-html-element-content-newline', rule, {
             options: [{allowEmptyLines: true}]
         },
         {
+            filename: 'test.san',
             code: `
             <template>
                 <div
@@ -209,6 +212,7 @@ tester.run('multiline-html-element-content-newline', rule, {
                 content</textarea>
         </template>`,
         {
+            filename: 'test.san',
             code: `
             <template>
                 <ignore-tag>content</ignore-tag>
@@ -227,6 +231,7 @@ tester.run('multiline-html-element-content-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
             <template>
                 <IgnoreTag>content</IgnoreTag>
@@ -245,6 +250,7 @@ tester.run('multiline-html-element-content-newline', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
             <template>
                 <ignore-tag>content</ignore-tag>
@@ -273,6 +279,7 @@ tester.run('multiline-html-element-content-newline', rule, {
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -310,6 +317,7 @@ content
         },
         // spaces
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -345,6 +353,7 @@ content
         },
         // elements
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div><div></div>
@@ -378,6 +387,7 @@ content
         },
         // contents
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>multiline
@@ -396,6 +406,7 @@ multiline
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>multiline content
@@ -410,6 +421,7 @@ multiline content
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>
@@ -425,6 +437,7 @@ multiline content
         },
         // comments
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div><!--comment-->
@@ -445,6 +458,7 @@ multiline content
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div><!--comment
@@ -466,6 +480,7 @@ multiline content
         },
         // one error
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>content
@@ -484,6 +499,7 @@ content
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>
@@ -503,6 +519,7 @@ content
         },
         // multi
         {
+            filename: 'test.san',
             code: `
                 <template><div>content<div>content
                 content</div>content</div></template>
@@ -528,6 +545,7 @@ content
         },
         // multi line breaks
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>
@@ -553,6 +571,7 @@ content
         },
         // allowEmptyLines
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -576,6 +595,7 @@ content
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>
@@ -610,6 +630,7 @@ content
         },
         // mustache
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>{{content}}
@@ -631,6 +652,7 @@ content
         },
         // mix
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div>content
@@ -654,6 +676,7 @@ content
         },
         // start tag
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -674,6 +697,7 @@ content
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div
@@ -694,6 +718,7 @@ content
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <div

--- a/__tests__/lib/rules/no-dupe-keys.test.js
+++ b/__tests__/lib/rules/no-dupe-keys.test.js
@@ -91,10 +91,6 @@ ruleTester.run('no-dupe-keys', rule, {
             errors: [
                 {
                     message: "Duplicated key 'foo'.",
-                    line: 7
-                },
-                {
-                    message: "Duplicated key 'foo'.",
                     line: 16
                 }
             ]
@@ -116,32 +112,6 @@ ruleTester.run('no-dupe-keys', rule, {
                 {
                     message: "Duplicated key 'bar'.",
                     line: 7
-                }
-            ]
-        },
-        {
-            filename: 'test.san',
-            code: `
-                export default {
-                    dataTypes: {
-                        foo: DataTypes.bool
-                    },
-                    initData () {
-                        return {
-                            get foo() {
-                                return foo
-                            },
-                            set foo(v) {
-                                foo = v
-                            }
-                        }
-                    }
-                }
-            `,
-            errors: [
-                {
-                    message: "Duplicated key 'foo'.",
-                    line: 8
                 }
             ]
         },

--- a/__tests__/lib/rules/no-multi-spaces.test.js
+++ b/__tests__/lib/rules/no-multi-spaces.test.js
@@ -48,6 +48,7 @@ ruleTester.run('no-multi-spaces', rule, {
             code: 'export default { }'
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <i
@@ -65,6 +66,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <i
@@ -84,6 +86,7 @@ ruleTester.run('no-multi-spaces', rule, {
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: '<template><div     /></template>',
             output: '<template><div /></template>',
             errors: [
@@ -94,6 +97,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div   class="foo"  /></template>',
             output: '<template><div class="foo" /></template>',
             errors: [
@@ -108,6 +112,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div\t\tclass="foo"\t\t/></template>',
             output: '<template><div class="foo" /></template>',
             errors: [
@@ -122,6 +127,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div   :class="foo"  /></template>',
             output: '<template><div :class="foo" /></template>',
             errors: [
@@ -136,6 +142,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div :foo="" class="foo"  /></template>',
             output: '<template><div :foo="" class="foo" /></template>',
             errors: [
@@ -146,6 +153,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div foo="" class="foo"  /></template>',
             output: '<template><div foo="" class="foo" /></template>',
             errors: [
@@ -156,6 +164,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><foo s-foo="" class="foo"  /></template>',
             output: '<template><foo s-foo="" class="foo" /></template>',
             errors: [
@@ -166,6 +175,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><foo s-foo="" \n         class="foo"    /></template>',
             output: '<template><foo s-foo="" \n         class="foo" /></template>',
             errors: [
@@ -176,6 +186,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div>{{  test  }}</div></template>',
             output: '<template><div>{{ test }}</div></template>',
             errors: [
@@ -190,6 +201,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div               ></div></template>',
             output: '<template><div ></div></template>',
             errors: [
@@ -200,6 +212,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="      i    in    b       ">{{ test }}</div></template>',
             output: '<template><div s-for=" i in b ">{{ test }}</div></template>',
             errors: [
@@ -222,6 +235,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <i
@@ -250,6 +264,7 @@ ruleTester.run('no-multi-spaces', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `
                 <template>
                     <i

--- a/__tests__/lib/rules/no-parsing-error.test.js
+++ b/__tests__/lib/rules/no-parsing-error.test.js
@@ -52,157 +52,195 @@ tester.run('no-parsing-error', rule, {
             code: '<a @click="foo(); bar()">link</a>'
         },
         {
+            
             filename: 'test.san',
             code: `<template s-for="x of list"><slot name="item" /></template>`
         },
         {
+            filename: 'test.san',
             code: `<template><!--></template>`,
             options: [{'abrupt-closing-of-empty-comment': false}]
         },
         {
+            filename: 'test.san',
             code: `<template><!---></template>`,
             options: [{'abrupt-closing-of-empty-comment': false}]
         },
         {
+            filename: 'test.san',
             code: `<template>&#qux;</template>`,
             options: [{'absence-of-digits-in-numeric-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><![CDATA[cdata]]></template>',
             options: [{'cdata-in-html-content': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&#1234567;</template>',
             options: [{'character-reference-outside-unicode-range': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>\u0003</template>',
             options: [{'control-character-in-input-stream': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&#0003;</template>',
             options: [{'control-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><',
             options: [{'eof-before-tag-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><svg><![CDATA[cdata',
             options: [{'eof-in-cdata': false}],
             errors: ['Parsing error: eof-in-cdata.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment',
             options: [{'eof-in-comment': false}],
             errors: ['Parsing error: eof-in-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><div class=""',
             options: [{'eof-in-tag': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment--!></template>',
             options: [{'incorrectly-closed-comment': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><!ELEMENT br EMPTY></template>',
             options: [{'incorrectly-opened-comment': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><👍>/template>',
             options: [{'invalid-first-character-of-tag-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div id=></template>',
             options: [{'missing-attribute-value': false}]
         },
         {
+            filename: 'test.san',
             code: '<template></></template>',
             options: [{'missing-end-tag-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&amp</template>',
             options: [{'missing-semicolon-after-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div id="foo"class="bar"></template>',
             options: [{'missing-whitespace-between-attributes': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><!--a<!--b--></template>',
             options: [{'nested-comment': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&#xFFFE;</template>',
             options: [{'noncharacter-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>\uFFFE</template>',
             options: [{'noncharacter-in-input-stream': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&#0000;</template>',
             options: [{'null-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&#xD800;</template>',
             options: [{'surrogate-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>\uD800</template>',
             options: [{'surrogate-in-input-stream': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div a"bc=""></template>',
             options: [{'unexpected-character-in-attribute-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div foo=bar"></template>',
             options: [{'unexpected-character-in-unquoted-attribute-value': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div =foo></template>',
             options: [{'unexpected-equals-sign-before-attribute-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>\u0000</template>',
             options: [{'unexpected-null-character': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><?xml?></template>',
             options: [{'unexpected-question-mark-instead-of-tag-name': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" / class=""></template>',
             options: [{'unexpected-solidus-in-tag': false}]
         },
         {
+            filename: 'test.san',
             code: '<template>&unknown;</template>',
             options: [{'unknown-named-character-reference': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div></div id=""></template>',
             options: [{'end-tag-with-attributes': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" id=""></div></template>',
             options: [{'duplicate-attribute': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div></div/></template>',
             options: [{'end-tag-with-trailing-solidus': false}]
         },
         {
+            filename: 'test.san',
             code: '<template><div/></template>',
             options: [{'non-void-html-element-start-tag-with-trailing-solidus': false}]
         },
         {
+            filename: 'test.san',
             code: '<template></div></template>',
             options: [{'x-invalid-end-tag': false}],
             errors: ['Parsing error: x-invalid-end-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template><div xmlns=""></template>',
             options: [{'x-invalid-namespace': false}]
         },
@@ -212,26 +250,31 @@ tester.run('no-parsing-error', rule, {
     ],
     invalid: [
         {
+            
             filename: 'test.san',
             code: '<template>{{a b c}}</template>',
             errors: ['Parsing error: Unexpected token b.']
         },
         {
+            
             filename: 'test.san',
             code: '<template><div>{{a b c}}</div></template>',
             errors: ['Parsing error: Unexpected token b.']
         },
         {
+            
             filename: 'test.san',
             code: '<template><div s-show="a b c">hello</div></template>',
             errors: ['Parsing error: Unexpected token b.']
         },
         {
+            
             filename: 'test.san',
             code: '<template><div s-show="a;b;">hello</div></template>',
             errors: ['Parsing error: Unexpected token ;.']
         },
         {
+            
             filename: 'test.san',
             code: '<template><div s-show=" ">hello</div></template>',
             errors: [
@@ -242,341 +285,416 @@ tester.run('no-parsing-error', rule, {
             ]
         },
         {
+            
             filename: 'test.san',
             code: '<template><div s-for="foo">hello</div></template>',
             errors: [{message: 'Parsing error: Unexpected end of expression.', column: 26}]
         },
         {
+            
             filename: 'test.san',
             code: '<template><div s-for="foo() in list">hello</div></template>',
             errors: [{message: 'Parsing error: Unexpected token (.', column: 26}]
         },
         {
+            filename: 'test.san',
             code: `<template><!--></template>`,
             options: [{'abrupt-closing-of-empty-comment': true}],
             errors: ['Parsing error: abrupt-closing-of-empty-comment.']
         },
         {
+            filename: 'test.san',
             code: `<template><!---></template>`,
             options: [{'abrupt-closing-of-empty-comment': true}],
             errors: ['Parsing error: abrupt-closing-of-empty-comment.']
         },
         {
+            filename: 'test.san',
             code: `<template>&#qux;</template>`,
             options: [{'absence-of-digits-in-numeric-character-reference': true}],
             errors: ['Parsing error: absence-of-digits-in-numeric-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><![CDATA[cdata]]></template>',
             options: [{'cdata-in-html-content': true}],
             errors: ['Parsing error: cdata-in-html-content.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#1234567;</template>',
             options: [{'character-reference-outside-unicode-range': true}],
             errors: ['Parsing error: character-reference-outside-unicode-range.']
         },
         {
+            filename: 'test.san',
             code: '<template>\u0003</template>',
             options: [{'control-character-in-input-stream': true}],
             errors: ['Parsing error: control-character-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#0003;</template>',
             options: [{'control-character-reference': true}],
             errors: ['Parsing error: control-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><',
             options: [{'eof-before-tag-name': true}],
             errors: ['Parsing error: eof-before-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><svg><![CDATA[cdata',
             options: [{'eof-in-cdata': true}],
             errors: ['Parsing error: eof-in-cdata.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment',
             options: [{'eof-in-comment': true}],
             errors: ['Parsing error: eof-in-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><div class=""',
             options: [{'eof-in-tag': true}],
             errors: ['Parsing error: eof-in-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment--!></template>',
             options: [{'incorrectly-closed-comment': true}],
             errors: ['Parsing error: incorrectly-closed-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><!ELEMENT br EMPTY></template>',
             options: [{'incorrectly-opened-comment': true}],
             errors: ['Parsing error: incorrectly-opened-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><👍>/template>',
             options: [{'invalid-first-character-of-tag-name': true}],
             errors: ['Parsing error: invalid-first-character-of-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id=></template>',
             options: [{'missing-attribute-value': true}],
             errors: ['Parsing error: missing-attribute-value.']
         },
         {
+            filename: 'test.san',
             code: '<template></></template>',
             options: [{'missing-end-tag-name': true}],
             errors: ['Parsing error: missing-end-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template>&amp</template>',
             options: [{'missing-semicolon-after-character-reference': true}],
             errors: ['Parsing error: missing-semicolon-after-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="foo"class="bar"></template>',
             options: [{'missing-whitespace-between-attributes': true}],
             errors: ['Parsing error: missing-whitespace-between-attributes.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--a<!--b--></template>',
             options: [{'nested-comment': true}],
             errors: ['Parsing error: nested-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#xFFFE;</template>',
             options: [{'noncharacter-character-reference': true}],
             errors: ['Parsing error: noncharacter-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>\uFFFE</template>',
             options: [{'noncharacter-in-input-stream': true}],
             errors: ['Parsing error: noncharacter-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#0000;</template>',
             options: [{'null-character-reference': true}],
             errors: ['Parsing error: null-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#xD800;</template>',
             options: [{'surrogate-character-reference': true}],
             errors: ['Parsing error: surrogate-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>\uD800</template>',
             options: [{'surrogate-in-input-stream': true}],
             errors: ['Parsing error: surrogate-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template><div a"bc=""></template>',
             options: [{'unexpected-character-in-attribute-name': true}],
             errors: ['Parsing error: unexpected-character-in-attribute-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div foo=bar"></template>',
             options: [{'unexpected-character-in-unquoted-attribute-value': true}],
             errors: ['Parsing error: unexpected-character-in-unquoted-attribute-value.']
         },
         {
+            filename: 'test.san',
             code: '<template><div =foo></template>',
             options: [{'unexpected-equals-sign-before-attribute-name': true}],
             errors: ['Parsing error: unexpected-equals-sign-before-attribute-name.']
         },
         {
+            filename: 'test.san',
             code: '<template>\u0000</template>',
             options: [{'unexpected-null-character': true}],
             errors: ['Parsing error: unexpected-null-character.']
         },
         {
+            filename: 'test.san',
             code: '<template><?xml?></template>',
             options: [{'unexpected-question-mark-instead-of-tag-name': true}],
             errors: ['Parsing error: unexpected-question-mark-instead-of-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" / class=""></template>',
             options: [{'unexpected-solidus-in-tag': true}],
             errors: ['Parsing error: unexpected-solidus-in-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template>&unknown;</template>',
             options: [{'unknown-named-character-reference': true}],
             errors: ['Parsing error: unknown-named-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><div></div id=""></template>',
             options: [{'end-tag-with-attributes': true}],
             errors: ['Parsing error: end-tag-with-attributes.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" id=""></div></template>',
             options: [{'duplicate-attribute': true}],
             errors: ['Parsing error: duplicate-attribute.']
         },
         {
+            filename: 'test.san',
             code: '<template><div></div/></template>',
             options: [{'end-tag-with-trailing-solidus': true}],
             errors: ['Parsing error: end-tag-with-trailing-solidus.']
         },
         {
+            filename: 'test.san',
             code: '<template><div/></template>',
             options: [{'non-void-html-element-start-tag-with-trailing-solidus': true}],
             errors: ['Parsing error: non-void-html-element-start-tag-with-trailing-solidus.']
         },
         {
+            filename: 'test.san',
             code: '<template></div></template>',
             options: [{'x-invalid-end-tag': true}],
             errors: ['Parsing error: x-invalid-end-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template><div xmlns=""></template>',
             options: [{'x-invalid-namespace': true}],
             errors: ['Parsing error: x-invalid-namespace.']
         },
         {
+            filename: 'test.san',
             code: `<template><!--></template>`,
             errors: ['Parsing error: abrupt-closing-of-empty-comment.']
         },
         {
+            filename: 'test.san',
             code: `<template><!---></template>`,
             errors: ['Parsing error: abrupt-closing-of-empty-comment.']
         },
         {
+            filename: 'test.san',
             code: `<template>&#qux;</template>`,
             errors: ['Parsing error: absence-of-digits-in-numeric-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><![CDATA[cdata]]></template>',
             errors: ['Parsing error: cdata-in-html-content.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#1234567;</template>',
             errors: ['Parsing error: character-reference-outside-unicode-range.']
         },
         {
+            filename: 'test.san',
             code: '<template>\u0003</template>',
             errors: ['Parsing error: control-character-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#0003;</template>',
             errors: ['Parsing error: control-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><',
             errors: ['Parsing error: eof-before-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><svg><![CDATA[cdata',
             errors: ['Parsing error: eof-in-cdata.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment',
             errors: ['Parsing error: eof-in-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><div class=""',
             errors: ['Parsing error: eof-in-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--comment--!></template>',
             errors: ['Parsing error: incorrectly-closed-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><!ELEMENT br EMPTY></template>',
             errors: ['Parsing error: incorrectly-opened-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template><👍>/template>',
             errors: ['Parsing error: invalid-first-character-of-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id=></template>',
             errors: ['Parsing error: missing-attribute-value.']
         },
         {
+            filename: 'test.san',
             code: '<template></></template>',
             errors: ['Parsing error: missing-end-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template>&amp</template>',
             errors: ['Parsing error: missing-semicolon-after-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="foo"class="bar"></template>',
             errors: ['Parsing error: missing-whitespace-between-attributes.']
         },
         {
+            filename: 'test.san',
             code: '<template><!--a<!--b--></template>',
             errors: ['Parsing error: nested-comment.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#xFFFE;</template>',
             errors: ['Parsing error: noncharacter-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>\uFFFE</template>',
             errors: ['Parsing error: noncharacter-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#0000;</template>',
             errors: ['Parsing error: null-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>&#xD800;</template>',
             errors: ['Parsing error: surrogate-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template>\uD800</template>',
             errors: ['Parsing error: surrogate-in-input-stream.']
         },
         {
+            filename: 'test.san',
             code: '<template><div a"bc=""></template>',
             errors: ['Parsing error: unexpected-character-in-attribute-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div foo=bar"></template>',
             errors: ['Parsing error: unexpected-character-in-unquoted-attribute-value.']
         },
         {
+            filename: 'test.san',
             code: '<template><div =foo></template>',
             errors: ['Parsing error: unexpected-equals-sign-before-attribute-name.']
         },
         {
+            filename: 'test.san',
             code: '<template>\u0000</template>',
             errors: ['Parsing error: unexpected-null-character.']
         },
         {
+            filename: 'test.san',
             code: '<template><?xml?></template>',
             errors: ['Parsing error: unexpected-question-mark-instead-of-tag-name.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" / class=""></template>',
             errors: ['Parsing error: unexpected-solidus-in-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template>&unknown;</template>',
             errors: ['Parsing error: unknown-named-character-reference.']
         },
         {
+            filename: 'test.san',
             code: '<template><div></div id=""></template>',
             errors: ['Parsing error: end-tag-with-attributes.']
         },
         {
+            filename: 'test.san',
             code: '<template><div id="" id=""></div></template>',
             errors: ['Parsing error: duplicate-attribute.']
         },
         {
+            filename: 'test.san',
             code: '<template><div></div/></template>',
             errors: ['Parsing error: end-tag-with-trailing-solidus.']
         },
         {
+            filename: 'test.san',
             code: '<template></div></template>',
             errors: ['Parsing error: x-invalid-end-tag.']
         },
         {
+            filename: 'test.san',
             code: '<template><div xmlns=""></template>',
             errors: ['Parsing error: x-invalid-namespace.']
         }

--- a/__tests__/lib/rules/no-reserved-keys.test.js
+++ b/__tests__/lib/rules/no-reserved-keys.test.js
@@ -102,23 +102,6 @@ ruleTester.run('no-reserved-keys', rule, {
             filename: 'test.js',
             code: `
                 san.defineComponent({
-                    dataTypes: {
-                        el: DataTypes.string
-                    }
-                })
-            `,
-            parserOptions: {ecmaVersion: 6},
-            errors: [
-                {
-                    message: "Key 'el' is reserved.",
-                    line: 4
-                }
-            ]
-        },
-        {
-            filename: 'test.js',
-            code: `
-                san.defineComponent({
                     attach() {
                         // ...
                     }

--- a/__tests__/lib/rules/no-shared-component-data.test.js
+++ b/__tests__/lib/rules/no-shared-component-data.test.js
@@ -8,7 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const rule = require('../../../lib/rules/no-shared-component-data');
+const rule = require('../../../lib/rules/initdata-in-component');
 
 const RuleTester = require('eslint').RuleTester;
 
@@ -22,7 +22,7 @@ const parserOptions = {
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
-ruleTester.run('no-shared-component-data', rule, {
+ruleTester.run('initdata-in-component', rule, {
     valid: [
         {
             filename: 'test.js',

--- a/__tests__/lib/rules/no-spaces-around-equal-signs-in-attribute.test.js
+++ b/__tests__/lib/rules/no-spaces-around-equal-signs-in-attribute.test.js
@@ -45,6 +45,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: '<template><div attr = "value" /></template>',
             output: '<template><div attr="value" /></template>',
             errors: [
@@ -58,6 +59,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div attr = "" /></template>',
             output: '<template><div attr="" /></template>',
             errors: [
@@ -71,6 +73,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: "<template><div attr = 'value' /></template>",
             output: "<template><div attr='value' /></template>",
             errors: [
@@ -84,6 +87,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div attr = value /></template>',
             output: '<template><div attr=value /></template>',
             errors: [
@@ -97,6 +101,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div attr \t\n   =   \t\n "value" /></template>',
             output: '<template><div attr="value" /></template>',
             errors: [
@@ -110,6 +115,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div attr ="value" /></template>',
             output: '<template><div attr="value" /></template>',
             errors: [
@@ -123,6 +129,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div attr= "value" /></template>',
             output: '<template><div attr="value" /></template>',
             errors: [
@@ -136,6 +143,7 @@ tester.run('no-spaces-around-equal-signs-in-attribute', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: `<template>
                 <div
                     is = "header"

--- a/__tests__/lib/rules/no-unused-vars.test.js
+++ b/__tests__/lib/rules/no-unused-vars.test.js
@@ -24,74 +24,94 @@ const tester = new RuleTester({
 tester.run('no-unused-vars', rule, {
     valid: [
         {
+            filename: 'test.san',
             code: '<template><ol s-for="i in 5"><li>{{i}}</li></ol></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><ol s-for="i in 5"><li :prop="i"></li></ol></template>'
         },
         {
+            filename: 'test.san',
             code: '<template s-for="i in 5"><comp s-for="j in 10">{{i}}{{j}}</comp></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><ol s-for="i in data"><li s-for="f in i">{{ f.bar.baz }}</li></ol></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><template scope="props">{{props}}</template></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><template scope="props"><span s-if="props"></span></template></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(item, key) in items" :key="key">{{item.name}}</div></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(v, i, c) in foo">{{c}}</div></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="x in foo">{{value | f(x)}}</div></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="x in foo" :[x]></div></template>'
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="_ in foo" ></div></template>',
             options: [{ignorePattern: '^_'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="ignorei in foo" ></div></template>',
             options: [{ignorePattern: '^ignore'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="thisisignore in foo" ></div></template>',
             options: [{ignorePattern: 'ignore$'}]
         }
     ],
     invalid: [
         {
+            filename: 'test.san',
             code: '<template><ol s-for="i in 5"><li></li></ol></template>',
             errors: ["'i' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><template scope="props"></template></template>',
             errors: ["'props' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><span slot-scope="props"></span></template>',
             errors: ["'props' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><span><template scope="props"></template></span></template>',
             errors: ["'props' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="i in 5"><comp s-for="j in 10">{{i}}{{i}}</comp></div></template>',
             errors: ["'j' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><ol s-for="i in data"><li s-for="f in i"></li></ol></template>',
             errors: ["'f' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(a, b, c) in foo"></div></template>',
             errors: [
                 "'a' is defined but never used.",
@@ -100,18 +120,22 @@ tester.run('no-unused-vars', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(a, b, c) in foo">{{a}}</div></template>',
             errors: ["'b' is defined but never used.", "'c' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(a, b, c) in foo">{{b}}</div></template>',
             errors: ["'c' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(item, key) in items" :key="item.id">{{item.name}}</div></template>',
             errors: ["'key' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="x in items">{{value | x}}</div></template>',
             errors: [
                 {
@@ -127,42 +151,51 @@ tester.run('no-unused-vars', rule, {
             options: [{ignorePattern: '^_'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="x in items">{{value}}</div></template>',
             options: [{ignorePattern: 'ignore$'}],
             errors: ["'x' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><span slot-scope="props"></span></template>',
             errors: ["'props' is defined but never used."],
             options: [{ignorePattern: '^ignore'}]
         },
         {
+            filename: 'test.san',
             code: '<template><span><template scope="props"></template></span></template>',
             errors: ["'props' is defined but never used."],
             options: [{ignorePattern: '^ignore'}]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="_i in foo" ></div></template>',
             errors: ["'_i' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="(a, _i) in foo" ></div></template>',
             options: [{ignorePattern: '^_'}],
             errors: ["'a' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><my-component s-slot="a" >{{d}}</my-component></template>',
             errors: ["'a' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><my-component s-for="i in foo" s-slot="a" >{{a}}</my-component></template>',
             errors: ["'i' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><my-component s-for="i in foo" s-slot="a" >{{i}}</my-component></template>',
             errors: ["'a' is defined but never used."]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="({a, b}, [c, d], e, f) in foo" >{{f}}</div></template>',
             errors: [
                 "'a' is defined but never used.",
@@ -172,6 +205,7 @@ tester.run('no-unused-vars', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="({a, b}, c, [d], e, f) in foo" >{{f}}</div></template>',
             errors: [
                 "'a' is defined but never used.",
@@ -180,6 +214,7 @@ tester.run('no-unused-vars', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><my-component s-slot="{a, b, c, d}" >{{d}}</my-component></template>',
             errors: [
                 "'a' is defined but never used.",
@@ -188,6 +223,7 @@ tester.run('no-unused-vars', rule, {
             ]
         },
         {
+            filename: 'test.san',
             code: '<template><div s-for="({a, b: bar}, c = 1, [d], e, f) in foo" >{{f}}</div></template>',
             errors: [
                 "'a' is defined but never used.",

--- a/__tests__/lib/rules/order-in-components.test.js
+++ b/__tests__/lib/rules/order-in-components.test.js
@@ -6,6 +6,8 @@
 
 const rule = require('../../../lib/rules/order-in-components');
 const RuleTester = require('eslint').RuleTester;
+require('@typescript-eslint/parser');
+require('san-eslint-parser');
 
 const ruleTester = new RuleTester();
 
@@ -135,6 +137,54 @@ ruleTester.run('order-in-components', rule, {
     ],
 
     invalid: [
+        {
+            filename: 'test.ts',
+            code: `
+                // @san/component
+                class A {
+                    static computed = {
+                        a() {
+                            return 3;
+                        }
+                    };
+                    initData() {
+                        return {
+                            b: 1
+                        }
+                    }
+                }
+            `,
+            parser: require.resolve('san-eslint-parser'),
+            parserOptions: {
+                parser: require.resolve('@typescript-eslint/parser'),
+                ecmaVersion: 6,
+                sourceType: "module",
+                ecmaFeatures: {
+                    classes: true
+                }
+            },
+            output: `
+                // @san/component
+                class A {
+                    static computed = {
+                        a() {
+                            return 3;
+                        }
+                    };
+                    initData() {
+                        return {
+                            b: 1
+                        }
+                    }
+                }
+            `,
+            errors: [
+                {
+                    message: 'The "initData" property should be above the "computed" property on line 4.',
+                    line: 9
+                }
+            ]
+        },
         {
             filename: 'test.san',
             code: `

--- a/__tests__/lib/rules/singleline-html-element-content-newline.test.js
+++ b/__tests__/lib/rules/singleline-html-element-content-newline.test.js
@@ -116,6 +116,7 @@ tester.run('singleline-html-element-content-newline', rule, {
 
         // ignoreWhenNoAttributes: false
         {
+          filename: 'test.san',
             code: `
       <template>
         <div>
@@ -125,6 +126,7 @@ tester.run('singleline-html-element-content-newline', rule, {
             options: [{ignoreWhenNoAttributes: false}]
         },
         {
+          filename: 'test.san',
             code: `
       <template>
         <div>
@@ -135,6 +137,7 @@ tester.run('singleline-html-element-content-newline', rule, {
             options: [{ignoreWhenNoAttributes: false}]
         },
         {
+          filename: 'test.san',
             code: `
       <template>
         <div>
@@ -159,6 +162,7 @@ tester.run('singleline-html-element-content-newline', rule, {
         <textarea><span attr>content</span></textarea>
       </template>`,
         {
+          filename: 'test.san',
             code: `
         <template>
           <ignore-tag>content</ignore-tag>
@@ -172,6 +176,7 @@ tester.run('singleline-html-element-content-newline', rule, {
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <IgnoreTag>content</IgnoreTag>
@@ -185,6 +190,7 @@ tester.run('singleline-html-element-content-newline', rule, {
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <ignore-tag>content</ignore-tag>
@@ -218,6 +224,7 @@ tester.run('singleline-html-element-content-newline', rule, {
     ],
     invalid: [
         {
+          filename: 'test.san',
             code: `
         <template>
           <div class="panel">content</div>
@@ -250,6 +257,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <tr attr><td>singleline</td><td>children</td></tr>
@@ -268,6 +276,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr><!-- singleline comment --></div>
@@ -286,6 +295,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr><!-- singleline --><!-- comments --></div>
@@ -304,6 +314,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr     >content</div    >
@@ -322,6 +333,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr     >content</div
@@ -342,6 +354,7 @@ content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr></div>
@@ -357,6 +370,7 @@ content
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div attr>    </div>
@@ -371,6 +385,7 @@ content
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div>singleline content</div>
@@ -390,6 +405,7 @@ singleline content
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <tr><td>singleline</td><td>children</td></tr>
@@ -417,6 +433,7 @@ children
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div><!-- singleline comment --></div>
@@ -436,6 +453,7 @@ children
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div   >   singleline element   </div   >
@@ -455,6 +473,7 @@ singleline element
             ]
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div></div>
@@ -470,6 +489,7 @@ singleline element
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <div>    </div>
@@ -485,6 +505,7 @@ singleline element
             errors: ['Expected 1 line break after opening tag (`<div>`), but no line breaks found.']
         },
         {
+          filename: 'test.san',
             code: `
         <template>
           <Div class="panel">content</Div>

--- a/__tests__/lib/rules/this-in-template.test.js
+++ b/__tests__/lib/rules/this-in-template.test.js
@@ -25,78 +25,97 @@ function createValidTests(prefix, options) {
     const comment = options.join('');
     return [
         {
+            filename: 'test.san',
             code: `<template><div>{{ ${prefix}foo.bar }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="foo in ${prefix}bar">{{ foo }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-if="${prefix}foo">{{ ${prefix}foo }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :class="${prefix}foo">{{ ${prefix}foo }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :class="{this: ${prefix}foo}">{{ ${prefix}foo }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="bar in ${prefix}foo" s-if="bar">{{ bar }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-if="${prefix}foo()">{{ ${prefix}bar }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :parent="this"></div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="x of ${prefix}xs">{{this.x}}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="x of ${prefix}xs">{{this.x()}}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="x of ${prefix}xs">{{this.x.y()}}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="x of ${prefix}xs">{{this.x['foo']}}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="x of ${prefix}xs">{{this['x']}}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ this.class }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ this['0'] }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ this['this'] }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ this['foo bar'] }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ }}</div></template><!-- ${comment} -->`,
             options
         },
         {
+            filename: 'test.san',
             code: `
             <template>
                 <div>
@@ -111,6 +130,7 @@ function createValidTests(prefix, options) {
 
         // We cannot use `.` in dynamic arguments because the right of the `.` becomes a modifier.
         {
+            filename: 'test.san',
             code: `<template><div s-on:[x]="1"></div></template><!-- ${comment} -->`,
             options
         }
@@ -121,41 +141,49 @@ function createInvalidTests(prefix, options, message, type) {
     const comment = options.join('');
     return [
         {
+            filename: 'test.san',
             code: `<template><div>{{ ${prefix}foo }}</div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ ${prefix}foo() }}</div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div>{{ ${prefix}foo.bar() }}</div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :class="${prefix}foo"></div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :class="{foo: ${prefix}foo}"></div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div :class="{foo: ${prefix}foo()}"></div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-if="${prefix}foo"></div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
         },
         {
+            filename: 'test.san',
             code: `<template><div s-for="foo in ${prefix}bar"></div></template><!-- ${comment} -->`,
             errors: [{message, type}],
             options
@@ -172,11 +200,13 @@ function createInvalidTests(prefix, options, message, type) {
             ? []
             : [
                   {
+                    filename: 'test.san',
                       code: `<template><div>{{ this['xs'] }}</div></template><!-- ${comment} -->`,
                       errors: [{message, type}],
                       options
                   },
                   {
+                    filename: 'test.san',
                       code: `<template><div>{{ this['xs0AZ_foo'] }}</div></template><!-- ${comment} -->`,
                       errors: [{message, type}],
                       options

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@
 | Draft | [san/no-multiple-template-root](./rules/no-multiple-template-root.md) | 禁止template出现多个根元素 |Done|
 | Draft | [san/no-parsing-error](./rules/no-parsing-error.md) | 禁止template语法解析错误 | Done |
 | Draft | [san/no-reserved-keys](./rules/no-reserved-keys.md) | 禁止覆写保留关键字 | Done |
-| Draft | [san/no-shared-component-data](./rules/no-shared-component-data.md) | 禁止组件实例共享data, initData必须为返回有效值的函数 | Done |
+| Draft | [san/initdata-in-component](./rules/initdata-in-component.md) | 禁止组件实例共享data, initData必须为返回有效值的函数 | Done |
 | Draft | [san/no-side-effects-in-computed-properties](./rules/no-side-effects-in-computed-properties.md) | 禁止有副作用的计算数据方法 | Done |
 | Draft | [san/no-template-key](./rules/no-template-key.md) | 禁止`<template>`使用属性 | Done |
 | Draft | [san/no-textarea-mustache](./rules/no-textarea-mustache.md) | 禁止`<textarea>`使用插值 | Done |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -44,7 +44,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | [vue/no-mutating-props](https://eslint.vuejs.org/rules/no-mutating-props.html) | disallow mutation of component props | ❌ | 没有相关语法 |  |
 | [vue/no-parsing-error](https://eslint.vuejs.org/rules/no-parsing-error.html) | disallow parsing errors in `<template>` | ✅ | | 已完成 |
 | [vue/no-reserved-keys](https://eslint.vuejs.org/rules/no-reserved-keys.html) | disallow overwriting reserved keys | ✅ | | 已完成 |
-| [vue/no-shared-component-data](https://eslint.vuejs.org/rules/no-shared-component-data.html) | enforce component's data property to be a function | ✅ | | 已完成 |
+| [vue/initdata-in-component](https://eslint.vuejs.org/rules/initdata-in-component.html) | enforce component's data property to be a function | ✅ | | 已完成 |
 | [vue/no-side-effects-in-computed-properties](https://eslint.vuejs.org/rules/no-side-effects-in-computed-properties.html) | disallow side effects in computed properties | ✅ | | 已完成 |
 | [vue/no-template-key](https://eslint.vuejs.org/rules/no-template-key.html) | disallow `key` attribute on `<template>` | ✅ | | 已完成 |
 | [vue/no-textarea-mustache](https://eslint.vuejs.org/rules/no-textarea-mustache.html) | disallow mustaches in `<textarea>` | ✅ | | 已完成 |

--- a/docs/rules/initdata-in-component.md
+++ b/docs/rules/initdata-in-component.md
@@ -1,10 +1,10 @@
 ---
 pageClass: rule-details
 sidebarDepth: 0
-title: san/no-shared-component-data
+title: san/initdata-in-component
 description: enforce component's data property to be a function
 ---
-# san/no-shared-component-data
+# san/initdata-in-component
 > enforce component's data property to be a function
 
 - :gear: This rule is included in all of `"plugin:san/essential"`, `"plugin:san/strongly-recommended"` and `"plugin:san/recommended"`.
@@ -16,7 +16,7 @@ When using the data property on a component , the value must be a function that 
 
 When the value of `data` is an object, it’s shared across all instances of a component.
 
-<eslint-code-block fix :rules="{'san/no-shared-component-data': ['error']}">
+<eslint-code-block fix :rules="{'san/initdata-in-component': ['error']}">
 
 ```vue
 <script>
@@ -28,30 +28,16 @@ export default class SomeComp extends san.Component {
     }
   }
 }
-
-export default {
-  initData () {
-    return {
-      foo: 'bar'
-    }
-  }
-}
 </script>
 ```
 
 </eslint-code-block>
 
-<eslint-code-block fix :rules="{'san/no-shared-component-data': ['error']}">
+<eslint-code-block fix :rules="{'san/initdata-in-component': ['error']}">
 
 ```vue
 <script>
 /* ✗ BAD */
-export default class SomeComp extends san.Component {
-  static initData = {
-    foo: 'bar'
-  }
-})
-
 export default {
   initData: {
     foo: 'bar'
@@ -72,5 +58,5 @@ Nothing.
 
 ## :mag: Implementation
 
-- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-shared-component-data.js)
-- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/no-shared-component-data.js)
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/initdata-in-component.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/initdata-in-component.js)

--- a/docs/rules/no-side-effects-in-computed-properties.md
+++ b/docs/rules/no-side-effects-in-computed-properties.md
@@ -47,7 +47,7 @@ export default {
   computed: {
     fullName () {
       this.data.set('firstName', 'lorem') // <- side effect
-      return `${this.data.set('firstName')} ${this.data.set('lastName')}`
+      return `${this.data.get('firstName')} ${this.data.get('lastName')}`
     },
     reversedArray () {
       return this.data.get('array').reverse() // <- side effect - orginal array is being mutated

--- a/lib/configs/essential.js
+++ b/lib/configs/essential.js
@@ -13,7 +13,7 @@ module.exports = {
         'san/no-multiple-template-root': 'error',
         'san/no-parsing-error': 'error',
         'san/no-reserved-keys': 'error',
-        'san/no-shared-component-data': 'error',
+        'san/initdata-in-component': 'error',
         'san/no-side-effects-in-computed-properties': 'error',
         'san/no-textarea-mustache': 'error',
         'san/no-unused-components': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const rules = [
     'no-multiple-template-root',
     'no-parsing-error',
     'no-reserved-keys',
-    'no-shared-component-data',
+    'initdata-in-component',
     'no-side-effects-in-computed-properties',
     'no-textarea-mustache',
     'no-unused-components',

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -48,6 +48,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         const option = context.options[0];
         const optionsPayload = context.options[1];

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -135,6 +135,9 @@ function isAlphabetical(prevNode, currNode, sourceCode) {
  * @returns {RuleListener} AST event handlers.
  */
 function create(context) {
+    if (!utils.isSanFile(context.getFilename())) {
+        return {};
+    }
     const sourceCode = context.getSourceCode();
     let attributeOrder = [
         ATTRS.DEFINITION,

--- a/lib/rules/comment-directive.js
+++ b/lib/rules/comment-directive.js
@@ -305,6 +305,9 @@ module.exports = {
      * @returns {RuleListener} AST event handlers.
      */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || {};
         /** @type {boolean} */
         const reportUnusedDisableDirectives = options.reportUnusedDisableDirectives;

--- a/lib/rules/component-tags-order.js
+++ b/lib/rules/component-tags-order.js
@@ -51,6 +51,9 @@ module.exports = {
      * @returns {RuleListener} AST event handlers.
      */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         /** @type {Map<string, number>} */
         const orderMap = new Map();
         /** @type {(string|string[])[]} */

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -77,6 +77,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const setupContexts = new Map();
 
         /**

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -57,6 +57,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = Object.assign(
             {},
             {

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -85,6 +85,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         const tokens =
             context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore();

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -30,6 +30,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         let hasInvalidEOF = false;
 
         return utils.defineTemplateBodyVisitor(

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -21,6 +21,9 @@ const utils = require('../utils');
 module.exports = {
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const tokenStore =
             context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore();
         const visitor = indentCommon.defineVisitor(context, tokenStore, {

--- a/lib/rules/html-quotes.js
+++ b/lib/rules/html-quotes.js
@@ -41,6 +41,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         const double = context.options[0] !== 'single';
         const avoidEscape = context.options[1] && context.options[1].avoidEscape === true;

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -137,6 +137,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         const options = parseOptions(context.options[0]);
         let hasInvalidEOF = false;

--- a/lib/rules/initdata-in-component.js
+++ b/lib/rules/initdata-in-component.js
@@ -63,16 +63,20 @@ module.exports = {
                 obj,
                 'initData',
                 p =>
-                    p.value.type !== 'FunctionExpression' &&
-                    p.value.type !== 'ArrowFunctionExpression' &&
-                    p.value.type !== 'Identifier'
+                    !p.value ||
+                    (
+                        p.value &&
+                        p.value.type !== 'FunctionExpression' &&
+                        p.value.type !== 'ArrowFunctionExpression' &&
+                        p.value.type !== 'Identifier'
+                    )
             );
             if (invalidData) {
                 context.report({
                     node: invalidData,
                     message: '`initData` property in component must be a function.',
                     fix(fixer) {
-                        const tokens = getFirstAndLastTokens(invalidData.value, sourceCode);
+                        const tokens = getFirstAndLastTokens(invalidData.value || invalidData, sourceCode);
 
                         return [
                             fixer.insertTextBefore(tokens.first, 'function() {\nreturn '),

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -69,6 +69,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         const configuration = parseOptions(context.options[0]);
         const multilineMaximum = configuration.multiline;

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -105,6 +105,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = parseOptions(context.options[0]);
         const ignores = options.ignores;
         const ignoreWhenEmpty = options.ignoreWhenEmpty;

--- a/lib/rules/mustache-interpolation-spacing.js
+++ b/lib/rules/mustache-interpolation-spacing.js
@@ -33,6 +33,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || 'always';
         const template =
             context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore();

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -16,7 +16,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 /** @type {GroupName[]} */
-const GROUP_NAMES = ['computed', 'initData', 'dataTypes'];
+const GROUP_NAMES = ['computed', 'initData'];
 
 module.exports = {
     meta: {

--- a/lib/rules/no-dupe-s-else-if.js
+++ b/lib/rules/no-dupe-s-else-if.js
@@ -93,6 +93,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const tokenStore =
             context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore();
         /**

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -65,6 +65,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || {};
         const allowCoexistStyle = options.allowCoexistStyle !== false;
         const allowCoexistClass = options.allowCoexistClass !== false;

--- a/lib/rules/no-lone-template.js
+++ b/lib/rules/no-lone-template.js
@@ -49,6 +49,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || {};
         const ignoreAccessible = options.ignoreAccessible === true;
 

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -5,8 +5,7 @@
 'use strict';
 
 /* eslint-disable */
-
-const path = require('path');
+const utils = require('../utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -48,14 +47,17 @@ module.exports = {
      * @returns {RuleListener} AST event handlers.
      */
     create(context) {
+        const isSanFile = utils.isSanFile(context.getFilename());
+        if (!isSanFile) {
+            return {};
+        }
         const options = context.options[0] || {};
         const ignoreProperties = options.ignoreProperties === true;
 
         return {
             Program(node) {
                 if (context.parserServices.getTemplateBodyTokenStore == null) {
-                    const filename = context.getFilename();
-                    if (path.extname(filename) === '.san') {
+                    if (isSanFile) {
                         context.report({
                             loc: {line: 1, column: 0},
                             message:

--- a/lib/rules/no-multiple-template-root.js
+++ b/lib/rules/no-multiple-template-root.js
@@ -32,6 +32,9 @@ module.exports = {
      * @returns {RuleListener} AST event handlers.
      */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
 
         return {

--- a/lib/rules/no-parsing-error.js
+++ b/lib/rules/no-parsing-error.js
@@ -4,6 +4,7 @@
  * See LICENSE file in root directory for full license.
  */
 'use strict';
+const utils = require('../utils');
 
 /* eslint-disable */
 
@@ -85,6 +86,9 @@ module.exports = {
      * @returns {RuleListener} AST event handlers.
      */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = Object.assign({}, DEFAULT_OPTIONS, context.options[0] || {});
 
         return {

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -19,7 +19,7 @@ const utils = require('../utils');
 
 const RESERVED_KEYS = require('../utils/san-reserved.json');
 /** @type {GroupName[]} */
-const GROUP_NAMES = ['dataTypes', 'computed', 'initData', 'filters'];
+const GROUP_NAMES = [];
 
 module.exports = {
     meta: {
@@ -57,21 +57,23 @@ module.exports = {
 
         return utils.executeOnSan(context, obj => {
             // modify by kidnes
-            for (const item of obj.properties) {
-                if (item.type !== 'Property') {
-                    continue;
-                }
-
-                const name = utils.getStaticPropertyName(item);
-                if (!name || RESERVED_KEYS.indexOf(name) === -1) continue;
-
-                context.report({
-                    node: item,
-                    message: "Key '{{name}}' is reserved.",
-                    data: {
-                        name
+            if (Array.isArray(obj.properties)) {
+                for (const item of obj.properties) {
+                    if (item.type !== 'Property') {
+                        continue;
                     }
-                });
+    
+                    const name = utils.getStaticPropertyName(item);
+                    if (!name || RESERVED_KEYS.indexOf(name) === -1) continue;
+    
+                    context.report({
+                        node: item,
+                        message: "Key '{{name}}' is reserved.",
+                        data: {
+                            name
+                        }
+                    });
+                }
             }
 
             const properties = utils.iterateProperties(obj, groups);

--- a/lib/rules/no-spaces-around-equal-signs-in-attribute.js
+++ b/lib/rules/no-spaces-around-equal-signs-in-attribute.js
@@ -29,6 +29,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
         return utils.defineTemplateBodyVisitor(context, {
             VAttribute(node) {

--- a/lib/rules/no-template-shadow.js
+++ b/lib/rules/no-template-shadow.js
@@ -36,6 +36,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         /** @type {Set<string>} */
         const jsVars = new Set();
 
@@ -92,15 +95,17 @@ module.exports = {
                 }
 
                 // for funtion not in methods. modify by kidnes
-                for (const item of obj.properties) {
-                    if (item.type !== 'Property') {
-                        continue;
+                if (Array.isArray(obj.properties)) {
+                    for (const item of obj.properties) {
+                        if (item.type !== 'Property') {
+                            continue;
+                        }
+    
+                        const name = utils.getStaticPropertyName(item);
+                        if (!name) continue;
+    
+                        jsVars.add(name);
                     }
-
-                    const name = utils.getStaticPropertyName(item);
-                    if (!name) continue;
-
-                    jsVars.add(name);
                 }
             })
         );

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -30,6 +30,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
             /** @param {VExpressionContainer} node */
             "VElement[name='textarea'] VExpressionContainer"(node) {

--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -40,6 +40,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || {};
         const ignoreWhenBindingPresent =
             options.ignoreWhenBindingPresent !== undefined ? options.ignoreWhenBindingPresent : true;

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -79,6 +79,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const option = context.options[0] || {};
         const ignorePattern = option.ignorePattern;
         /** @type {RegExp | null} */

--- a/lib/rules/no-use-s-if-with-s-for.js
+++ b/lib/rules/no-use-s-if-with-s-for.js
@@ -69,6 +69,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] || {};
         const allowUsingIterationVar = options.allowUsingIterationVar === true; // default false
         return utils.defineTemplateBodyVisitor(context, {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -185,6 +185,10 @@ module.exports = {
         const orderMap = getOrderMap(extendedOrder);
         const sourceCode = context.getSourceCode();
 
+        function filterProp(prop) {
+            return utils.isProperty(prop) || utils.isClassProperty(prop) || utils.isMethodDefinition(prop);
+        }
+
         /**
          * @param {string} name
          */
@@ -197,7 +201,10 @@ module.exports = {
          * @param {(Property | SpreadElement)[]} propertiesNodes
          */
         function checkOrder(propertiesNodes) {
-            const properties = propertiesNodes.filter(utils.isProperty).map(property => {
+            if (!Array.isArray(propertiesNodes)) {
+                return;
+            }
+            const properties = propertiesNodes.filter(filterProp).map(property => {
                 return {
                     node: property,
                     name:
@@ -208,6 +215,7 @@ module.exports = {
             });
 
             properties.forEach((property, i) => {
+                debugger;
                 const orderPos = getOrderPosition(property.name);
                 if (orderPos < 0) {
                     return;
@@ -262,7 +270,11 @@ module.exports = {
         }
 
         return utils.executeOnSan(context, obj => {
-            checkOrder(obj.properties);
+            if (obj.type === 'ClassBody') {
+                checkOrder(obj.body);
+            } else {
+                checkOrder(obj.properties);
+            }
         });
     }
 };

--- a/lib/rules/singleline-html-element-content-newline.js
+++ b/lib/rules/singleline-html-element-content-newline.js
@@ -94,6 +94,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = parseOptions(context.options[0]);
         const ignores = options.ignores;
         const ignoreWhenNoAttributes = options.ignoreWhenNoAttributes;

--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -40,6 +40,9 @@ module.exports = {
      * @returns {Object} AST event handlers.
      */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const options = context.options[0] !== 'always' ? 'never' : 'always';
         /**
          * @typedef {object} ScopeStack

--- a/lib/rules/valid-s-else-if.js
+++ b/lib/rules/valid-s-else-if.js
@@ -31,6 +31,9 @@ module.exports = {
 
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
 
             /** @param {VDirective} node */

--- a/lib/rules/valid-s-else.js
+++ b/lib/rules/valid-s-else.js
@@ -31,6 +31,9 @@ module.exports = {
 
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
 
             /** @param {VDirective} node */

--- a/lib/rules/valid-s-for.js
+++ b/lib/rules/valid-s-for.js
@@ -30,6 +30,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
             /** @param {VDirective} node */
             "VAttribute[directive=true][key.name.name='for']"(node) {

--- a/lib/rules/valid-s-if.js
+++ b/lib/rules/valid-s-if.js
@@ -31,6 +31,9 @@ module.exports = {
 
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
 
             /** @param {VDirective} node */

--- a/lib/rules/valid-s-show.js
+++ b/lib/rules/valid-s-show.js
@@ -30,6 +30,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         return utils.defineTemplateBodyVisitor(context, {
 
             /** @param {VDirective} node */

--- a/lib/rules/valid-template-root.js
+++ b/lib/rules/valid-template-root.js
@@ -30,6 +30,9 @@ module.exports = {
     },
     /** @param {RuleContext} context */
     create(context) {
+        if (!utils.isSanFile(context.getFilename())) {
+            return {};
+        }
         const sourceCode = context.getSourceCode();
 
         return {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -420,21 +420,24 @@ module.exports = {
      * @returns {VAttribute | null} The found attribute.
      */
     getAttribute(node, name, value) {
-        return (
-            node.startTag.attributes.find(
-                /**
-                 * @param {VAttribute | VDirective} node
-                 * @returns {node is VAttribute}
-                 */
-                node => {
-                    return (
-                        !node.directive &&
-                        node.key.name === name &&
-                        (value === undefined || (node.value != null && node.value.value === value))
-                    );
-                }
-            ) || null
-        );
+        if (node.startTag && node.startTag.attributes && typeof node.startTag.attributes.find === 'function') {
+            return (
+                node.startTag.attributes.find(
+                    /**
+                     * @param {VAttribute | VDirective} node
+                     * @returns {node is VAttribute}
+                     */
+                    node => {
+                        return (
+                            !node.directive &&
+                            node.key.name === name &&
+                            (value === undefined || (node.value != null && node.value.value === value))
+                        );
+                    }
+                ) || null
+            );
+        }
+        return null;
     },
 
     /**
@@ -757,20 +760,41 @@ module.exports = {
      * @return {ComponentComputedProperty[]} Array of computed properties in format: [{key: String, value: ASTNode}]
      */
     getComputedProperties(componentObject) {
-        const computedPropertiesNode = componentObject.properties.find(
-            /**
-             * @param {ESNode} p
-             * @returns {p is (Property & { key: Identifier & {name: 'computed'}, value: ObjectExpression })}
-             */
-            p => {
-                return (
-                    p.type === 'Property' &&
-                    p.key.type === 'Identifier' &&
-                    p.key.name === 'computed' &&
-                    p.value.type === 'ObjectExpression'
-                );
-            }
-        );
+        if (!componentObject) {
+            return [];
+        }
+        let computedPropertiesNode = null;
+        if (componentObject.type === 'ClassBody' && componentObject.body) {
+            computedPropertiesNode = componentObject.body.find(
+                /**
+                 * @param {ESNode} p
+                 * @returns {p is (Property & { key: Identifier & {name: 'computed'}, value: ObjectExpression })}
+                 */
+                p => {
+                    return (
+                        p.type === 'ClassProperty' &&
+                        p.key.type === 'Identifier' &&
+                        p.key.name === 'computed' &&
+                        p.value.type === 'ObjectExpression'
+                    );
+                }
+            );
+        } else if (componentObject.properties) {
+            computedPropertiesNode = componentObject.properties.find(
+                /**
+                 * @param {ESNode} p
+                 * @returns {p is (Property & { key: Identifier & {name: 'computed'}, value: ObjectExpression })}
+                 */
+                p => {
+                    return (
+                        p.type === 'Property' &&
+                        p.key.type === 'Identifier' &&
+                        p.key.name === 'computed' &&
+                        p.value.type === 'ObjectExpression'
+                    );
+                }
+            );
+        }
 
         if (!computedPropertiesNode) {
             return [];
@@ -848,10 +872,18 @@ module.exports = {
             sanVisitor[key] = node => callVisitor(key, node);
         }
 
+        // sanVisitor.ClassBody = node => {
+
+        // }
+
+        // sanVisitor['ClassBody:exit'] = node => {
+            
+        // }
+
         /**
          * @param {ObjectExpression} node
          */
-        sanVisitor.ObjectExpression = node => {
+        sanVisitor.ObjectExpression = sanVisitor.ClassBody =node => {
             const type = getSanObjectType(context, node);
             if (type) {
                 sanStack = {
@@ -879,7 +911,7 @@ module.exports = {
             }
             callVisitor('ObjectExpression', node);
         };
-        sanVisitor['ObjectExpression:exit'] = node => {
+        sanVisitor['ObjectExpression:exit'] = sanVisitor['ClassBody:exit'] = node => {
             callVisitor('ObjectExpression:exit', node);
             if (sanStack && sanStack.node === node) {
                 callVisitor('onSanObjectExit', node);
@@ -937,6 +969,11 @@ module.exports = {
                 const type = getSanObjectType(context, node);
                 if (!type || (type !== 'mark' && type !== 'export' && type !== 'definition')) return;
                 cb(node, type);
+            },
+            'ClassBody:exit'(node) {
+                const type = getSanObjectType(context, node);
+                if (!type || (type !== 'mark' && type !== 'export' && type !== 'definition')) return;
+                cb(node, type);
             }
         };
     },
@@ -975,25 +1012,43 @@ module.exports = {
      * @returns {IterableIterator<ComponentPropertyData>}
      */
     *iterateProperties(node, groups) {
-        debugger;
-        for (const item of node.properties) {
-            if (item.type !== 'Property') {
-                continue;
+        if (node.type === 'ObjectExpression') {
+            const props = node.properties;
+            for (const item of props) {
+                if (item.type !== 'Property') {
+                    continue;
+                }
+    
+                const name = /** @type {GroupName | null} */ (getStaticPropertyName(item));
+                if (!name || !groups.has(name)) continue;
+    
+                if (item.value.type === 'ArrayExpression') {
+                    yield* this.iterateArrayExpression(item.value, name);
+                } else if (item.value.type === 'ObjectExpression') {
+                    yield* this.iterateObjectExpression(item.value, name);
+                } else if (item.value.type === 'FunctionExpression') {
+                    yield* this.iterateFunctionExpression(item.value, name);
+                } else if (item.value.type === 'ArrowFunctionExpression') {
+                    yield* this.iterateArrowFunctionExpression(item.value, name);
+                }
             }
-
-            const name = /** @type {GroupName | null} */ (getStaticPropertyName(item));
-            if (!name || !groups.has(name)) continue;
-
-            if (item.value.type === 'ArrayExpression') {
-                yield* this.iterateArrayExpression(item.value, name);
-            } else if (item.value.type === 'ObjectExpression') {
-                yield* this.iterateObjectExpression(item.value, name);
-            } else if (item.value.type === 'FunctionExpression') {
-                yield* this.iterateFunctionExpression(item.value, name);
-            } else if (item.value.type === 'ArrowFunctionExpression') {
-                yield* this.iterateArrowFunctionExpression(item.value, name);
+        } else if (node.type === 'ClassBody') {
+            const body = node.body;
+            for (const item of body) {
+                const name = /** @type {GroupName | null} */ (getStaticPropertyName(item));
+                if (!name || !groups.has(name) || !item.value) continue;
+                if (item.value.type === 'ArrayExpression') {
+                    yield* this.iterateArrayExpression(item.value, name);
+                } else if (item.value.type === 'ObjectExpression') {
+                    yield* this.iterateObjectExpression(item.value, name);
+                } else if (item.value.type === 'FunctionExpression') {
+                    yield* this.iterateFunctionExpression(item.value, name);
+                } else if (item.value.type === 'ArrowFunctionExpression') {
+                    yield* this.iterateArrowFunctionExpression(item.value, name);
+                }
             }
         }
+
     },
 
     /**
@@ -1237,6 +1292,8 @@ module.exports = {
         }
         return dp[alen][blen];
     },
+    isClassProperty,
+    isMethodDefinition,
     /**
      * Checks whether the given node is Property.
      */
@@ -1520,7 +1577,21 @@ function compositingVisitors(visitor, ...visitors) {
  * @returns { (Property) | null}
  */
 function findProperty(node, name, filter) {
-    const predicate = filter
+    if (node.type === 'ClassBody' && node.body) {
+        const predicate = filter
+        ? /**
+           * @param {Property | SpreadElement} prop
+           * @returns {prop is Property}
+           */
+          prop => isClassProperty(prop) && getStaticPropertyName(prop) === name && filter(prop)
+        : /**
+           * @param {Property | SpreadElement} prop
+           * @returns {prop is Property}
+           */
+          prop => isClassProperty(prop) && getStaticPropertyName(prop) === name;
+        return node.body.find(predicate) || null;
+    } else if (node && node.properties && typeof node.properties.find === 'function') {
+        const predicate = filter
         ? /**
            * @param {Property | SpreadElement} prop
            * @returns {prop is Property}
@@ -1531,7 +1602,9 @@ function findProperty(node, name, filter) {
            * @returns {prop is Property}
            */
           prop => isProperty(prop) && getStaticPropertyName(prop) === name;
-    return node.properties.find(predicate) || null;
+        return node.properties.find(predicate) || null;
+    }
+    return null;
 }
 
 /**
@@ -1542,7 +1615,8 @@ function findProperty(node, name, filter) {
  * @returns { (AssignmentProperty) | null}
  */
 function findAssignmentProperty(node, name, filter) {
-    const predicate = filter
+    if (node && node.properties && typeof node.properties.find === 'function') {
+        const predicate = filter
         ? /**
            * @param {AssignmentProperty | RestElement} prop
            * @returns {prop is AssignmentProperty}
@@ -1553,7 +1627,9 @@ function findAssignmentProperty(node, name, filter) {
            * @returns {prop is AssignmentProperty}
            */
           prop => isAssignmentProperty(prop) && getStaticPropertyName(prop) === name;
-    return node.properties.find(predicate) || null;
+        return node.properties.find(predicate) || null;
+    }
+    return null;
 }
 
 /**
@@ -1563,6 +1639,14 @@ function findAssignmentProperty(node, name, filter) {
  */
 function isProperty(node) {
     return node.type === 'Property';
+}
+
+function isClassProperty(node) {
+    return node.type === 'ClassProperty';
+}
+
+function isMethodDefinition(node) {
+    return node.type === 'MethodDefinition';
 }
 /**
  * Checks whether the given node is AssignmentProperty.
@@ -1670,7 +1754,7 @@ function skipChainExpression(node) {
  * @return {string|null} The property name if static. Otherwise, null.
  */
 function getStaticPropertyName(node) {
-    if (node.type === 'Property' || node.type === 'MethodDefinition') {
+    if (node.type === 'Property' || node.type === 'MethodDefinition' || node.type === 'ClassProperty') {
         const key = node.key;
 
         if (!node.computed) {
@@ -1731,8 +1815,8 @@ function getStringLiteralValue(node, stringOnly) {
 /**
  * @param {string} path
  */
-function isSanFile(path) {
-    return path.endsWith('.san') || path.endsWith('.jsx');
+function isSanFile(filename) {
+    return path.extname(filename) === '.san';
 }
 
 /**
@@ -1833,7 +1917,7 @@ function isSanInstance(node) {
  * @returns { SanObjectType | null } The San definition type.
  */
 function getSanObjectType(context, node) {
-    if (node.type !== 'ObjectExpression') {
+    if (node.type !== 'ObjectExpression' && node.type !== 'ClassBody') {
         return null;
     }
     const parent = getParent(node);


### PR DESCRIPTION
@ksky521 
## 对 ts 文件检测能力增强
### 需要解决的两个问题
1. 无法识别非 san 文件中的类组件（ts中能够识别export default {} 以及 san.defineComponent）—— 已解决
2. 无法检测非 san 文件的 template（san-eslint-parser 无法有效的处理 template）- 待解决

### 根据san 与 vue 的区别做如下规则修改：不涉及非 template 的检测规则
1. 删除 [no-shared-component-data](https://kidnes.github.io/eslint-plugin-san/rules/no-shared-component-data.html) 规则，新增 initdata-in-component 规则用于检测 initData 是否是一个函数
2. [no-dupe-keys](https://kidnes.github.io/eslint-plugin-san/rules/no-dupe-keys.html) 规则只检测 initData 与 computed 中是否有重复的值
3. [no-reserved-keys](https://kidnes.github.io/eslint-plugin-san/rules/no-reserved-keys.html) 规则只检测实例与属性方法是否命中保留关键字
4. 修正 5 条规则在类组件中表现不正常的问题
    - [no-async-in-computed-properties](https://kidnes.github.io/eslint-plugin-san/rules/no-async-in-computed-properties.html)
    - [no-side-effects-in-computed-properties](https://kidnes.github.io/eslint-plugin-san/rules/no-side-effects-in-computed-properties.html)
    - [one-component-per-file](https://kidnes.github.io/eslint-plugin-san/rules/one-component-per-file.html)
    - [order-in-components](https://kidnes.github.io/eslint-plugin-san/rules/order-in-components.html)
    - [return-in-computed-property](https://kidnes.github.io/eslint-plugin-san/rules/return-in-computed-property.html)