### PR TITLE
add two rules / docs

### DIFF
--- a/__tests__/lib/rules/data-name-casing.test.js
+++ b/__tests__/lib/rules/data-name-casing.test.js
@@ -1,0 +1,107 @@
+/**
+ * @author jinjingxuan
+ */
+ 'use strict';
+
+ // ------------------------------------------------------------------------------
+ // Requirements
+ // ------------------------------------------------------------------------------
+ 
+ const rule = require('../../../lib/rules/data-name-casing');
+ 
+ const RuleTester = require('eslint').RuleTester;
+ 
+ // ------------------------------------------------------------------------------
+ // Tests
+ // ------------------------------------------------------------------------------
+
+ const tester = new RuleTester({
+    parser: require.resolve('san-eslint-parser'),
+    parserOptions: {
+        ecmaVersion: 2015,
+        sourceType: 'module'
+    }
+});
+
+tester.run('data-name-casing', rule, {
+    valid: [
+        {
+            filename: 'test.san',
+            code: `
+                <script>
+                export default {
+                    dataTypes: {
+                        greetingText: DataTypes.string
+                    },
+                    computed: {
+                        aText() {
+                            return this.data.get('text') + 1;
+                        },
+                        bText() {
+                            return this.data.get('text') + 2;
+                        }
+                    },
+                    initData() {
+                        return {
+                            text: 1
+                        }
+                    },
+                }
+                </script>
+            `
+        },
+    ],
+    invalid: [
+        {
+            filename: 'test.san',
+            code: `
+                <script>
+                export default {
+                    dataTypes: {
+                        'greeting-text': DataTypes.string
+                    },
+                    computed: {
+                        'a-text'() {
+                            return this.data.get('text') + 1;
+                        },
+                        'b_text'() {
+                            return this.data.get('text') + 2;
+                        }
+                    },
+                    initData() {
+                        return {
+                            text: 1,
+                            's-text': 2,
+                        }
+                    },
+                }
+                </script>
+            `,
+            errors: [
+                {
+                    message: "dataTypes 'greeting-text' must be camel case",
+                    line: 5,
+                    column: 25,
+                    endLine: 5,
+                    endColumn: 40,
+                },
+                {
+                    message: "computed 'a-text' must be camel case",
+                    line: 8,
+                    column: 25,
+                },
+                {
+                    message: "computed 'b_text' must be camel case",
+                    line: 11,
+                    column: 25,
+                },
+                {
+                    message: "initData 's-text' must be camel case",
+                    line: 18,
+                    column: 29,
+                }
+            ]
+        },
+    ]
+})
+

--- a/__tests__/lib/rules/data-name-casing.test.js
+++ b/__tests__/lib/rules/data-name-casing.test.js
@@ -66,7 +66,10 @@ tester.run('data-name-casing', rule, {
                         },
                         'b_text'() {
                             return this.data.get('text') + 2;
-                        }
+                        },
+                        'CText'() {
+                            return this.data.get('text') + 3;
+                        },
                     },
                     initData() {
                         return {
@@ -96,8 +99,13 @@ tester.run('data-name-casing', rule, {
                     column: 25,
                 },
                 {
+                    message: "computed 'CText' must be camel case",
+                    line: 14,
+                    column: 25,
+                },
+                {
                     message: "initData 's-text' must be camel case",
-                    line: 18,
+                    line: 21,
                     column: 29,
                 }
             ]

--- a/__tests__/lib/rules/no-empty-attributes.test.js
+++ b/__tests__/lib/rules/no-empty-attributes.test.js
@@ -43,7 +43,6 @@ tester.run('no-empty-attributes', rule, {
                         <div class="a"></div>
                         <div style="b"></div>
                         <div attr=""></div>
-                        <div attr></div>
                     </div>
                 </template>
             `
@@ -68,10 +67,8 @@ tester.run('no-empty-attributes', rule, {
             code: `
                 <template>
                     <div>
-                        <div class=""></div>
+                        <div class=" "></div>
                         <div style=""></div>
-                        <div class></div>
-                        <div style></div>
                     </div>
                 </template>
             `,
@@ -84,16 +81,6 @@ tester.run('no-empty-attributes', rule, {
                 {
                     message: "disallow attribute 'style' is empty",
                     line: 5,
-                    column: 30,
-                },
-                {
-                    message: "disallow attribute 'class' is empty",
-                    line: 6,
-                    column: 30,
-                },
-                {
-                    message: "disallow attribute 'style' is empty",
-                    line: 7,
                     column: 30,
                 }
             ],

--- a/__tests__/lib/rules/no-empty-attributes.test.js
+++ b/__tests__/lib/rules/no-empty-attributes.test.js
@@ -1,0 +1,123 @@
+/**
+ * @author jinjingxuan
+ */
+ 'use strict';
+
+ // ------------------------------------------------------------------------------
+ // Requirements
+ // ------------------------------------------------------------------------------
+ 
+ const rule = require('../../../lib/rules/no-empty-attributes');
+ 
+ const RuleTester = require('eslint').RuleTester;
+ 
+ // ------------------------------------------------------------------------------
+ // Tests
+ // ------------------------------------------------------------------------------
+
+ const tester = new RuleTester({
+    parser: require.resolve('san-eslint-parser'),
+    parserOptions: {
+        ecmaVersion: 2015
+    }
+});
+
+tester.run('no-empty-attributes', rule, {
+    valid: [
+        {
+            filename: 'test.san',
+            code: `
+                <template>
+                    <div>
+                        <div class="a"></div>
+                        <div style="b"></div>
+                    </div>
+                </template>
+            `
+        },
+        {
+            filename: 'test.san',
+            code: `
+                <template>
+                    <div>
+                        <div class="a"></div>
+                        <div style="b"></div>
+                        <div attr=""></div>
+                        <div attr></div>
+                    </div>
+                </template>
+            `
+        },
+        {
+            filename: 'test.san',
+            code: `
+                <template>
+                    <div>
+                        <div class="a"></div>
+                        <div style="b"></div>
+                        <div attr="c"></div>
+                    </div>
+                </template>
+            `,
+            options: [{groups: ['attr']}]
+        }
+    ],
+    invalid: [
+        {
+            filename: 'test.san',
+            code: `
+                <template>
+                    <div>
+                        <div class=""></div>
+                        <div style=""></div>
+                        <div class></div>
+                        <div style></div>
+                    </div>
+                </template>
+            `,
+            errors: [
+                {
+                    message: "disallow attribute 'class' is empty",
+                    line: 4,
+                    column: 30,
+                },
+                {
+                    message: "disallow attribute 'style' is empty",
+                    line: 5,
+                    column: 30,
+                },
+                {
+                    message: "disallow attribute 'class' is empty",
+                    line: 6,
+                    column: 30,
+                },
+                {
+                    message: "disallow attribute 'style' is empty",
+                    line: 7,
+                    column: 30,
+                }
+            ],
+        },
+        {
+            filename: 'test.san',
+            code: `
+                <template>
+                    <div>
+                        <div class="a"></div>
+                        <div style="b"></div>
+                        <div attr=""></div>
+                    </div>
+                </template>
+            `,
+            errors: [
+                {
+                    message: "disallow attribute 'attr' is empty",
+                    line: 6,
+                    column: 30,
+                }
+            ],
+            options: [{groups: ['attr']}]
+        },
+    ]
+})
+

--- a/docs/rules/data-name-casing.md
+++ b/docs/rules/data-name-casing.md
@@ -1,0 +1,69 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: san/data-name-casing
+description: data names always use "camel-case"
+---
+# san/data-name-casing
+> enforce data names always use "camel-case"
+
+- :gear: This rule is included in all of `"plugin:san/essential"`, `"plugin:san/strongly-recommended"` and `"plugin:san/recommended"`.
+
+## :book: Rule Details
+
+`computed`、`dataTypes`、`initData` properties name must be camel-case , it will not work when the property name is snakeCase、kebabCase or PascalCase.
+
+<eslint-code-block :rules="{'san/data-name-casing': ['error']}">
+
+```vue
+<script>
+export default {
+  /* ✓ GOOD */
+  dataTypes: {
+    datatypeText: DataTypes.string
+  },
+  computed: {
+    aText() {
+      return this.data.get('text') + 'a';
+    }
+  },
+  initData() {
+    return {
+      text: 'text'
+    }
+  },
+  
+  /* ✗ BAD */
+  dataTypes: {
+    'datatype-text': DataTypes.string
+  },
+  computed: {
+    /* PascalCase */
+    'AText'() {
+      return this.data.get('text_bad') + 'a';
+    },
+    /* snakeCase */
+    'b_text'() {
+      return this.data.get('text_bad') + 'b';
+    },
+    /* kebabCase */
+    'c-text'() {
+      return this.data.get('text_bad') + 'c';
+    }
+  },
+  initData() {
+    return {
+      text_bad: 'text'
+    }
+  },
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/data-name-casing.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/tests/lib/rules/data-name-casing.js)
+

--- a/docs/rules/no-empty-attributes.md
+++ b/docs/rules/no-empty-attributes.md
@@ -1,0 +1,69 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: san/no-empty-attributes
+description: disallow empty of attributes
+---
+# san/no-empty-attributes
+> disallow empty of attributes
+
+- :gear: This rule is included in all of `"plugin:san/essential"`, `"plugin:san/strongly-recommended"` and `"plugin:san/recommended"`.
+
+## :book: Rule Details
+
+This rule requires that the class attribute and style attribute cannot be empty by default.
+
+<eslint-code-block :rules="{'san/no-empty-attributes': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div class="abc" />
+  <div style="abc" />
+
+  <!-- ✗ BAD -->
+  <div class="" />
+  <div style="" />
+  <div class=" " />
+  <div style=" " />
+</template>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+```js
+{
+    "san/no-empty-attributes": ["error", {
+        groups: ['attr']
+    }],
+}
+```
+
+* `groups`：In addition to the class  and style, you can also add additional attributes that cannot be empty through group.
+
+### `groups: ['attr']`
+
+<eslint-code-block :rules="{'san/no-empty-attributes': ['error', { groups: ['attr'] }]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div class="abc" />
+  <div style="abc" />
+  <div attr="abc" />
+
+  <!-- ✗ BAD -->
+  <div class="" />
+  <div style="" />
+  <div attr="" />
+  <div attr=" " />
+</template>
+```
+
+</eslint-code-block>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ecomfe/eslint-plugin-san/blob/master/lib/rules/no-empty-attributes.js)
+- [Test source](https://github.com/ecomfe/eslint-plugin-san/blob/master/__tests__/lib/rules/no-empty-attributes.js)

--- a/lib/configs/essential.js
+++ b/lib/configs/essential.js
@@ -7,10 +7,12 @@ module.exports = {
     rules: {
         'san/valid-components-name': 'error',
         'san/custom-event-name-casing': 'error',
+        'san/data-name-casing': 'error',
         'san/no-async-in-computed-properties': 'error',
         'san/no-dupe-keys': 'error',
         'san/no-dupe-s-else-if': 'error',
         'san/no-duplicate-attributes': 'error',
+        'san/no-empty-attributes': 'error',
         'san/no-multiple-template-root': 'error',
         'san/no-parsing-error': 'error',
         'san/no-reserved-keys': 'error',
@@ -26,7 +28,7 @@ module.exports = {
         'san/valid-s-else': 'error',
         'san/valid-s-for': 'error',
         'san/valid-s-if': 'error',
-        'san/valid-s-show': 'error'
+        'san/valid-s-show': 'error',
         // 'san/valid-on': 'error',
         // 'san/valid-twoway-binding': 'error',
     }

--- a/lib/configs/essential.js
+++ b/lib/configs/essential.js
@@ -28,7 +28,7 @@ module.exports = {
         'san/valid-s-else': 'error',
         'san/valid-s-for': 'error',
         'san/valid-s-if': 'error',
-        'san/valid-s-show': 'error',
+        'san/valid-s-show': 'error'
         // 'san/valid-on': 'error',
         // 'san/valid-twoway-binding': 'error',
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,12 @@ const rules = [
     // essential
     'valid-components-name',
     'custom-event-name-casing',
+    'data-name-casing',
     'no-async-in-computed-properties',
     'no-dupe-keys',
     'no-dupe-s-else-if',
     'no-duplicate-attributes',
+    'no-empty-attributes',
     'no-multiple-template-root',
     'no-parsing-error',
     'no-reserved-keys',

--- a/lib/rules/data-name-casing.js
+++ b/lib/rules/data-name-casing.js
@@ -1,0 +1,58 @@
+/**
+ * @author jinjingxuan
+ */
+'use strict';
+
+/* eslint-disable */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils');
+const {isCamelCase} = require('../utils/casing');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/** @type {GroupName[]} */
+const GROUP_NAMES = ['dataTypes', 'initData', 'computed'];
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'require datatypes is camelcase',
+            categories: ['essential'],
+            url: ''
+        },
+        fixable: null,
+        schema: []
+    },
+    /** @param {RuleContext} context */
+    create(context) {
+        const groups = new Set(GROUP_NAMES);
+
+        // ----------------------------------------------------------------------
+        // Public
+        // ----------------------------------------------------------------------
+
+        return utils.executeOnSan(context, obj => {
+            const properties = utils.iterateProperties(obj, groups);
+            
+            for (const o of properties) {
+                if (!isCamelCase(o.name)) {
+                    context.report({
+                        node: o.node,
+                        message: "{{group}} '{{name}}' must be camel case",
+                        data: {
+                            name: o.name,
+                            group: o.groupName,
+                        }
+                    });
+                }
+            }
+        });
+    }
+};

--- a/lib/rules/data-name-casing.js
+++ b/lib/rules/data-name-casing.js
@@ -17,7 +17,7 @@ const {isCamelCase} = require('../utils/casing');
 // ------------------------------------------------------------------------------
 
 /** @type {GroupName[]} */
-const GROUP_NAMES = ['dataTypes', 'initData', 'computed'];
+const GROUP_NAMES = new Set(['dataTypes', 'initData', 'computed']);
 
 module.exports = {
     meta: {
@@ -25,21 +25,20 @@ module.exports = {
         docs: {
             description: 'require datatypes is camelcase',
             categories: ['essential'],
-            url: ''
+            url: 'https://ecomfe.github.io/eslint-plugin-san/rules/data-name-casing.html'
         },
         fixable: null,
         schema: []
     },
     /** @param {RuleContext} context */
     create(context) {
-        const groups = new Set(GROUP_NAMES);
 
         // ----------------------------------------------------------------------
         // Public
         // ----------------------------------------------------------------------
 
         return utils.executeOnSan(context, obj => {
-            const properties = utils.iterateProperties(obj, groups);
+            const properties = utils.iterateProperties(obj, GROUP_NAMES);
             
             for (const o of properties) {
                 if (!isCamelCase(o.name)) {

--- a/lib/rules/no-empty-attributes.js
+++ b/lib/rules/no-empty-attributes.js
@@ -1,0 +1,63 @@
+/**
+ * @author jinjingxuan
+ */
+'use strict';
+
+/* eslint-disable */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/** @type {GroupName[]} */
+const GROUP_NAMES = ['class', 'style'];
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'disallow empty attribute',
+            categories: ['essential'],
+            url: ''
+        },
+        fixable: null,
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    groups: {
+                        type: 'array'
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+    /** @param {RuleContext} context */
+    create(context) {
+        const options = context.options[0] || {};
+        const groups = GROUP_NAMES.concat(options.groups || []);
+
+        return utils.defineTemplateBodyVisitor(context, {
+            VAttribute(node) {
+                if (groups.includes(node.key.name) 
+                    && (node.value === null || node.value.value === '')
+                ) {
+                    context.report({
+                        node: node,
+                        message: "disallow attribute '{{name}}' is empty",
+                        data: {
+                            name: node.key.name
+                        }
+                    });
+                }
+            }
+        });
+    }
+};

--- a/lib/rules/no-empty-attributes.js
+++ b/lib/rules/no-empty-attributes.js
@@ -24,7 +24,7 @@ module.exports = {
         docs: {
             description: 'disallow empty attribute',
             categories: ['essential'],
-            url: ''
+            url: 'https://ecomfe.github.io/eslint-plugin-san/rules/no-empty-attributes.html'
         },
         fixable: null,
         schema: [
@@ -47,7 +47,8 @@ module.exports = {
         return utils.defineTemplateBodyVisitor(context, {
             VAttribute(node) {
                 if (groups.includes(node.key.name) 
-                    && (node.value === null || node.value.value === '')
+                    && node.value 
+                    && node.value.value.trim() === ''
                 ) {
                     context.report({
                         node: node,


### PR DESCRIPTION
新增两条规则：
1. no-empty-attributes: 默认检测 class 和 style 属性不能为空，可以通过 options 配置其他不允许为空的属性。
2. data-name-casing：dataTypes, initData, computed 中的数据在多个单词的情况下使用 "下划线"、"短横线"、"帕斯卡"命名规则会报错，提示统一使用驼峰式命名法。